### PR TITLE
Add .gitignore

### DIFF
--- a/risk-calculator/risk-calculator/.gitignore
+++ b/risk-calculator/risk-calculator/.gitignore
@@ -1,0 +1,37 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+
+# Virtual environments
+venv/
+.venv/
+env/
+.env/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Flask / SQLite
+instance/
+*.db
+*.sqlite3
+
+# Environment variables
+.env
+.env.*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/


### PR DESCRIPTION
No `.gitignore` exists — contributors inadvertently commit `__pycache__`, `.db` files, and virtual environments. This adds standard coverage for a Python/Flask project.