### PR TITLE
Add materiality inputs, references popover, and responsive canvas scaling

### DIFF
--- a/risk-calculator/frontend/.gitignore
+++ b/risk-calculator/frontend/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.local
+.env
+.env.*
+*.log
+.vite/

--- a/risk-calculator/frontend/index.html
+++ b/risk-calculator/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FAIR™ Risk Calculator</title>
+  </head>
+  <body class="bg-canvas text-ink">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/risk-calculator/frontend/package-lock.json
+++ b/risk-calculator/frontend/package-lock.json
@@ -1,0 +1,4168 @@
+{
+  "name": "risk-calculator-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "risk-calculator-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@radix-ui/react-popover": "^1.1.2",
+        "@radix-ui/react-select": "^2.1.2",
+        "@radix-ui/react-slider": "^1.2.1",
+        "@radix-ui/react-tooltip": "^1.1.4",
+        "@tanstack/react-query": "^5.59.16",
+        "@xyflow/react": "^12.3.5",
+        "clsx": "^2.1.1",
+        "framer-motion": "^11.11.17",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "recharts": "^2.13.3",
+        "zustand": "^5.0.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.3",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.49",
+        "tailwindcss": "^3.4.14",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.10"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.13.tgz",
+      "integrity": "sha512-mlKVKMTzZWGTKAC1CKOgt7axAjJ921emkEvYIp27I/PdP1yEYL/BteLY8iK35gn8hoYeKB4mgJ/ve3lrDI6/Fw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.13.tgz",
+      "integrity": "sha512-HSBr8CycQEAoXsJR7KNDawBnINJEJ96Eme8oE0hCXjyodE2I97vg3IDzDJBDu18LsbzpVVJcKo80eqLfVCykxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.13"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.29",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/risk-calculator/frontend/package.json
+++ b/risk-calculator/frontend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "risk-calculator-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 5000 --host",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 5000"
+  },
+  "dependencies": {
+    "@radix-ui/react-slider": "^1.2.1",
+    "@radix-ui/react-tooltip": "^1.1.4",
+    "@radix-ui/react-select": "^2.1.2",
+    "@radix-ui/react-popover": "^1.1.2",
+    "@tanstack/react-query": "^5.59.16",
+    "@xyflow/react": "^12.3.5",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.11.17",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "recharts": "^2.13.3",
+    "zustand": "^5.0.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/risk-calculator/frontend/postcss.config.js
+++ b/risk-calculator/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/risk-calculator/frontend/src/App.tsx
+++ b/risk-calculator/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import InputTable from "./components/InputTable";
 import Toggle from "./components/Toggle";
 import ScenarioSummary from "./components/ScenarioSummary";
 import ResultsView from "./components/ResultsView";
+import References from "./components/References";
 import { useStore } from "./lib/state";
 
 export default function App() {
@@ -97,9 +98,10 @@ export default function App() {
         </section>
       </main>
 
-      <footer className="border-t border-ink px-6 py-3 text-xs text-ink">
-        scaffold v0.1 · tree wired · dials live · simulation next
+      <footer className="border-t border-ink px-6 py-3 text-xs text-ink flex items-center justify-between gap-3">
+        <span>Open FAIR Risk Calculator · React frontend</span>
       </footer>
+      <References />
     </div>
   );
 }

--- a/risk-calculator/frontend/src/App.tsx
+++ b/risk-calculator/frontend/src/App.tsx
@@ -3,9 +3,7 @@ import FairTree from "./components/FairTree";
 import InputTable from "./components/InputTable";
 import Toggle from "./components/Toggle";
 import ScenarioSummary from "./components/ScenarioSummary";
-import Histogram from "./components/Histogram";
-import ExceedanceCurve from "./components/ExceedanceCurve";
-import SummaryStats from "./components/SummaryStats";
+import ResultsView from "./components/ResultsView";
 import { useStore } from "./lib/state";
 
 export default function App() {
@@ -90,29 +88,7 @@ export default function App() {
         <section className="p-6 bg-panel-grey/40">
           <h2 className="text-base font-semibold text-ink mb-4">Results</h2>
           {result ? (
-            <div className="space-y-4">
-              <SummaryStats summary={result.summary} iterations={result.iterations} />
-              <div className="grid lg:grid-cols-2 gap-4">
-                <div className="rounded-xl border border-ink bg-canvas p-3">
-                  <h3 className="text-sm font-semibold text-ink mb-2">
-                    Annualized Loss Expectancy distribution
-                  </h3>
-                  <Histogram
-                    counts={result.histogram.counts}
-                    bins={result.histogram.bins}
-                  />
-                </div>
-                <div className="rounded-xl border border-ink bg-canvas p-3">
-                  <h3 className="text-sm font-semibold text-ink mb-2">
-                    Loss exceedance curve
-                  </h3>
-                  <ExceedanceCurve
-                    values={result.exceedance.values}
-                    probabilities={result.exceedance.probabilities}
-                  />
-                </div>
-              </div>
-            </div>
+            <ResultsView result={result} />
           ) : (
             <div className="rounded-xl border border-ink bg-canvas h-[300px] flex items-center justify-center text-ink text-sm">
               Click Run Scenario to see the distribution and statistics

--- a/risk-calculator/frontend/src/App.tsx
+++ b/risk-calculator/frontend/src/App.tsx
@@ -2,12 +2,17 @@ import { useEffect, useState } from "react";
 import FairTree from "./components/FairTree";
 import InputTable from "./components/InputTable";
 import Toggle from "./components/Toggle";
+import ScenarioSummary from "./components/ScenarioSummary";
+import Histogram from "./components/Histogram";
+import ExceedanceCurve from "./components/ExceedanceCurve";
+import SummaryStats from "./components/SummaryStats";
 import { useStore } from "./lib/state";
 
 export default function App() {
   const [backendOk, setBackendOk] = useState<boolean | null>(null);
   const tableFrozen = useStore((s) => s.tableFrozen);
   const setTableFrozen = useStore((s) => s.setTableFrozen);
+  const result = useStore((s) => s.result);
 
   useEffect(() => {
     fetch("/api/scenarios")
@@ -75,11 +80,44 @@ export default function App() {
           </div>
         </section>
 
+        <section className="border-b border-ink p-6 overflow-auto bg-canvas">
+          <h2 className="text-base font-semibold text-ink mb-4 text-center">
+            Scenario Summary
+          </h2>
+          <ScenarioSummary />
+        </section>
+
         <section className="p-6 bg-panel-grey/40">
           <h2 className="text-base font-semibold text-ink mb-4">Results</h2>
-          <div className="rounded-xl border border-ink bg-canvas h-[480px] flex items-center justify-center text-ink text-sm">
-            run a simulation to see distributions
-          </div>
+          {result ? (
+            <div className="space-y-4">
+              <SummaryStats summary={result.summary} iterations={result.iterations} />
+              <div className="grid lg:grid-cols-2 gap-4">
+                <div className="rounded-xl border border-ink bg-canvas p-3">
+                  <h3 className="text-sm font-semibold text-ink mb-2">
+                    Annualized Loss Expectancy distribution
+                  </h3>
+                  <Histogram
+                    counts={result.histogram.counts}
+                    bins={result.histogram.bins}
+                  />
+                </div>
+                <div className="rounded-xl border border-ink bg-canvas p-3">
+                  <h3 className="text-sm font-semibold text-ink mb-2">
+                    Loss exceedance curve
+                  </h3>
+                  <ExceedanceCurve
+                    values={result.exceedance.values}
+                    probabilities={result.exceedance.probabilities}
+                  />
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-xl border border-ink bg-canvas h-[300px] flex items-center justify-center text-ink text-sm">
+              Click Run Scenario to see the distribution and statistics
+            </div>
+          )}
         </section>
       </main>
 

--- a/risk-calculator/frontend/src/App.tsx
+++ b/risk-calculator/frontend/src/App.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import FairTree from "./components/FairTree";
+import InputTable from "./components/InputTable";
+import Toggle from "./components/Toggle";
+import { useStore } from "./lib/state";
+
+export default function App() {
+  const [backendOk, setBackendOk] = useState<boolean | null>(null);
+  const tableFrozen = useStore((s) => s.tableFrozen);
+  const setTableFrozen = useStore((s) => s.setTableFrozen);
+
+  useEffect(() => {
+    fetch("/api/scenarios")
+      .then((r) => setBackendOk(r.ok))
+      .catch(() => setBackendOk(false));
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-canvas">
+      <header className="border-b border-ink px-6 py-4 flex items-center justify-between bg-canvas">
+        <div className="flex items-baseline gap-3">
+          <h1 className="text-xl font-bold text-ink tracking-tight">
+            FAIR<sup className="text-[6px] font-semibold relative -top-2.5 ml-px">TM</sup> Risk Calculator
+          </h1>
+          <span className="text-xs text-ink">
+            Factor Analysis of Information Risk
+          </span>
+        </div>
+        <div className="flex items-center gap-3 text-sm">
+          <button
+            onClick={() => window.print()}
+            className="no-print px-3 py-1 bg-button-grey border border-ink rounded text-sm font-semibold text-ink hover:brightness-95"
+          >
+            Generate PDF
+          </button>
+          <span className="text-ink">backend</span>
+          <span
+            className={
+              "px-2 py-0.5 rounded-full text-xs font-semibold " +
+              (backendOk === null
+                ? "bg-button-grey text-ink"
+                : backendOk
+                ? "bg-input-blue text-canvas"
+                : "bg-red-100 text-red-700")
+            }
+          >
+            {backendOk === null ? "checking" : backendOk ? "connected" : "offline"}
+          </span>
+        </div>
+      </header>
+
+      <main className="flex-1 flex flex-col">
+        <section className="border-b border-ink p-6 overflow-auto bg-canvas">
+          <div className="rounded-xl border border-ink bg-canvas p-4 overflow-auto">
+            <FairTree />
+          </div>
+        </section>
+
+        <section className="border-b border-ink p-6 overflow-auto bg-canvas">
+          <div className="relative">
+            <h2 className="text-base font-semibold text-ink mb-4 text-center">
+              Input Table
+            </h2>
+            <div
+              className="absolute top-0 -translate-x-1/2 z-10"
+              style={{ left: 64 }}
+            >
+              <Toggle
+                label="Freeze table"
+                on={tableFrozen}
+                onChange={(v) => setTableFrozen(v)}
+              />
+            </div>
+            <InputTable />
+          </div>
+        </section>
+
+        <section className="p-6 bg-panel-grey/40">
+          <h2 className="text-base font-semibold text-ink mb-4">Results</h2>
+          <div className="rounded-xl border border-ink bg-canvas h-[480px] flex items-center justify-center text-ink text-sm">
+            run a simulation to see distributions
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-ink px-6 py-3 text-xs text-ink">
+        scaffold v0.1 · tree wired · dials live · simulation next
+      </footer>
+    </div>
+  );
+}

--- a/risk-calculator/frontend/src/components/Dial.tsx
+++ b/risk-calculator/frontend/src/components/Dial.tsx
@@ -1,0 +1,123 @@
+import * as Slider from "@radix-ui/react-slider";
+import { Triangular } from "../lib/state";
+
+type Props = {
+  value: Triangular;
+  baseline: Triangular;
+  bound: [number, number];
+  step: number;
+  unit: string;
+  onChange: (v: Triangular) => void;
+  onReset: () => void;
+};
+
+const dialSize = 110;
+
+export default function Dial({ value, baseline, bound, step, unit, onChange, onReset }: Props) {
+  const [lo, hi] = bound;
+  const span = Math.max(hi - lo, 1e-9);
+  const angle = ((value.likely - lo) / span) * 270 - 135;
+  const setKey = (key: keyof Triangular, v: number) =>
+    onChange({ ...value, [key]: clamp(v, lo, hi) });
+
+  return (
+    <div className="flex flex-col items-center gap-3 p-1">
+      <div
+        className="relative"
+        style={{ width: dialSize, height: dialSize }}
+        aria-label="dial visual"
+      >
+        <svg width={dialSize} height={dialSize} viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#e5e7eb" strokeWidth="6" />
+          <circle
+            cx="50"
+            cy="50"
+            r="44"
+            fill="none"
+            stroke="#9ca3af"
+            strokeWidth="6"
+            strokeDasharray={`${((value.likely - lo) / span) * 207} 999`}
+            strokeLinecap="round"
+            transform="rotate(-225 50 50)"
+          />
+          <line
+            x1="50"
+            y1="50"
+            x2={50 + 32 * Math.cos((angle * Math.PI) / 180)}
+            y2={50 + 32 * Math.sin((angle * Math.PI) / 180)}
+            stroke="#1d4ed8"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+          <circle cx="50" cy="50" r="5" fill="#1d4ed8" />
+        </svg>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 w-full text-[11px]">
+        <NumField label="min"    value={value.min}    onChange={(v) => setKey("min",    v)} step={step} bound={bound} />
+        <NumField label="likely" value={value.likely} onChange={(v) => setKey("likely", v)} step={step} bound={bound} highlight />
+        <NumField label="max"    value={value.max}    onChange={(v) => setKey("max",    v)} step={step} bound={bound} />
+      </div>
+
+      <Slider.Root
+        className="relative flex items-center w-full h-5"
+        min={lo}
+        max={hi}
+        step={step}
+        value={[value.likely]}
+        onValueChange={([v]) => setKey("likely", v)}
+      >
+        <Slider.Track className="bg-button-grey relative grow rounded-full h-1.5">
+          <Slider.Range className="absolute bg-input-blue rounded-full h-full" />
+        </Slider.Track>
+        <Slider.Thumb className="block w-4 h-4 bg-input-blue rounded-full focus:outline-none focus:ring-2 focus:ring-input-blue/40" />
+      </Slider.Root>
+
+      <div className="w-full text-[11px] flex items-center justify-between">
+        <span className="text-ink">baseline likely: <b className="text-ink">{format(baseline.likely, unit)}</b></span>
+        <button onClick={onReset} className="px-2 py-0.5 rounded border border-ink text-ink hover:bg-button-grey">
+          reset
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function NumField({
+  label, value, onChange, step, bound, highlight,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  step: number;
+  bound: [number, number];
+  highlight?: boolean;
+}) {
+  return (
+    <label className="flex flex-col text-ink">
+      <span className="uppercase tracking-wide">{label}</span>
+      <input
+        type="number"
+        value={value}
+        step={step}
+        min={bound[0]}
+        max={bound[1]}
+        onChange={(e) => onChange(parseFloat(e.target.value || "0"))}
+        className={
+          "border rounded px-1 py-0.5 text-ink bg-canvas " +
+          (highlight ? "border-input-blue font-bold" : "border-ink")
+        }
+      />
+    </label>
+  );
+}
+
+function clamp(v: number, lo: number, hi: number) {
+  return Math.min(hi, Math.max(lo, isFinite(v) ? v : lo));
+}
+
+function format(v: number, unit: string): string {
+  if (unit === "USD") return `$${Math.round(v).toLocaleString("en-US")}`;
+  if (unit === "probability" || unit === "0 to 1") return `${Math.round(v * 100)}%`;
+  return `${Math.round(v)}`;
+}

--- a/risk-calculator/frontend/src/components/Dial.tsx
+++ b/risk-calculator/frontend/src/components/Dial.tsx
@@ -22,37 +22,6 @@ export default function Dial({ value, baseline, bound, step, unit, onChange, onR
 
   return (
     <div className="flex flex-col items-center gap-3 p-1">
-      <div
-        className="relative"
-        style={{ width: dialSize, height: dialSize }}
-        aria-label="dial visual"
-      >
-        <svg width={dialSize} height={dialSize} viewBox="0 0 100 100">
-          <circle cx="50" cy="50" r="44" fill="none" stroke="#e5e7eb" strokeWidth="6" />
-          <circle
-            cx="50"
-            cy="50"
-            r="44"
-            fill="none"
-            stroke="#9ca3af"
-            strokeWidth="6"
-            strokeDasharray={`${((value.likely - lo) / span) * 207} 999`}
-            strokeLinecap="round"
-            transform="rotate(-225 50 50)"
-          />
-          <line
-            x1="50"
-            y1="50"
-            x2={50 + 32 * Math.cos((angle * Math.PI) / 180)}
-            y2={50 + 32 * Math.sin((angle * Math.PI) / 180)}
-            stroke="#1d4ed8"
-            strokeWidth="3"
-            strokeLinecap="round"
-          />
-          <circle cx="50" cy="50" r="5" fill="#1d4ed8" />
-        </svg>
-      </div>
-
       <div className="grid grid-cols-3 gap-2 w-full text-[11px]">
         <NumField label="min"    value={value.min}    onChange={(v) => setKey("min",    v)} step={step} bound={bound} />
         <NumField label="likely" value={value.likely} onChange={(v) => setKey("likely", v)} step={step} bound={bound} highlight />

--- a/risk-calculator/frontend/src/components/ExceedanceCurve.tsx
+++ b/risk-calculator/frontend/src/components/ExceedanceCurve.tsx
@@ -1,0 +1,60 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import { fmtUsd, fmtUsdShort } from "../lib/compute";
+
+type Props = {
+  values: number[];
+  probabilities: number[];
+  materiality?: number | null;
+};
+
+export default function ExceedanceCurve({ values, probabilities, materiality }: Props) {
+  const data = values.map((v, i) => ({ value: v, prob: probabilities[i] }));
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <LineChart data={data} margin={{ top: 8, right: 8, bottom: 4, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis
+          dataKey="value"
+          tickFormatter={(v) => fmtUsdShort(v)}
+          tick={{ fontSize: 10, fill: "#000" }}
+          stroke="#9ca3af"
+        />
+        <YAxis
+          tickFormatter={(v) => `${v.toFixed(0)}%`}
+          tick={{ fontSize: 10, fill: "#000" }}
+          stroke="#9ca3af"
+        />
+        <Tooltip
+          formatter={(v: number) => `${v.toFixed(1)}%`}
+          labelFormatter={(v: number) => `Loss ≥ ${fmtUsd(v)}`}
+          contentStyle={{ fontSize: 11 }}
+        />
+        <Line
+          dataKey="prob"
+          type="monotone"
+          stroke="#1d4ed8"
+          strokeWidth={2}
+          dot={false}
+        />
+        {materiality && (
+          <ReferenceLine
+            x={materiality}
+            stroke="#000"
+            strokeDasharray="4 2"
+            label={{ value: "materiality", position: "top", fill: "#000", fontSize: 10 }}
+          />
+        )}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/risk-calculator/frontend/src/components/ExceedanceCurve.tsx
+++ b/risk-calculator/frontend/src/components/ExceedanceCurve.tsx
@@ -14,25 +14,41 @@ type Props = {
   values: number[];
   probabilities: number[];
   materiality?: number | null;
+  onHover?: (text: string | null) => void;
 };
 
-export default function ExceedanceCurve({ values, probabilities, materiality }: Props) {
+export default function ExceedanceCurve({ values, probabilities, materiality, onHover }: Props) {
   const data = values.map((v, i) => ({ value: v, prob: probabilities[i] }));
 
   return (
-    <ResponsiveContainer width="100%" height={220}>
-      <LineChart data={data} margin={{ top: 8, right: 8, bottom: 4, left: 0 }}>
+    <ResponsiveContainer width="100%" height={280}>
+      <LineChart
+        data={data}
+        margin={{ top: 10, right: 10, bottom: 8, left: 8 }}
+        onMouseMove={(s: any) => {
+          if (s && s.activePayload && s.activePayload.length) {
+            const d = s.activePayload[0].payload;
+            onHover?.(
+              `There is a ${d.prob.toFixed(
+                1
+              )} percent chance that annual losses will exceed ${fmtUsd(d.value)}.`
+            );
+          }
+        }}
+        onMouseLeave={() => onHover?.(null)}
+      >
         <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
         <XAxis
           dataKey="value"
           tickFormatter={(v) => fmtUsdShort(v)}
-          tick={{ fontSize: 10, fill: "#000" }}
-          stroke="#9ca3af"
+          tick={{ fontSize: 13, fill: "#000" }}
+          stroke="#000"
+          minTickGap={60}
         />
         <YAxis
           tickFormatter={(v) => `${v.toFixed(0)}%`}
-          tick={{ fontSize: 10, fill: "#000" }}
-          stroke="#9ca3af"
+          tick={{ fontSize: 13, fill: "#000" }}
+          stroke="#000"
         />
         <Tooltip
           formatter={(v: number) => `${v.toFixed(1)}%`}

--- a/risk-calculator/frontend/src/components/FairTree.tsx
+++ b/risk-calculator/frontend/src/components/FairTree.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { useStore } from "../lib/state";
 import {
   fmtCount,
@@ -13,29 +14,32 @@ import {
 import TreeNode from "./TreeNode";
 import ScenarioTable from "./ScenarioTable";
 import Toggle from "./Toggle";
+import MaterialityInput from "./MaterialityInput";
 
 const CANVAS_W = 1570;
-const CANVAS_H = 740;
-const COLLAPSED_H = 200;
+const CANVAS_H = 870;
+const COLLAPSED_H = 320;
 
 const SCOPE_LABEL_Y = 8;
 const TABLE = { x: 165, y: 44, width: 1240, height: 80 };
-const TREE_LABEL_Y = 152;
+const MATERIALITY_LABEL_Y = 140;
+const MATERIALITY_Y = 176;
+const TREE_LABEL_Y = 282;
 
 const POS = {
-  risk:    { x: 785,  y: 230 },
-  lef:     { x: 460,  y: 360 },
-  lm:      { x: 1110, y: 360 },
-  tef:     { x: 215,  y: 500 },
-  vuln:    { x: 705,  y: 500 },
-  pl:      { x: 995,  y: 500 },
-  sl:      { x: 1225, y: 500 },
-  cf:      { x: 105,  y: 650 },
-  poa:     { x: 325,  y: 650 },
-  tc:      { x: 595,  y: 650 },
-  rs:      { x: 815,  y: 650 },
-  slef:    { x: 1115, y: 650 },
-  slm:     { x: 1335, y: 650 },
+  risk:    { x: 785,  y: 360 },
+  lef:     { x: 460,  y: 490 },
+  lm:      { x: 1110, y: 490 },
+  tef:     { x: 215,  y: 630 },
+  vuln:    { x: 705,  y: 630 },
+  pl:      { x: 995,  y: 630 },
+  sl:      { x: 1225, y: 630 },
+  cf:      { x: 105,  y: 780 },
+  poa:     { x: 325,  y: 780 },
+  tc:      { x: 595,  y: 780 },
+  rs:      { x: 815,  y: 780 },
+  slef:    { x: 1115, y: 780 },
+  slm:     { x: 1335, y: 780 },
 } as const;
 
 type Op = "x" | "+" | "MC";
@@ -76,10 +80,35 @@ export default function FairTree() {
   const lm = rollupLm(inputs.primaryLoss, sl);
   const risk = rollupRisk(lef, lm);
 
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  useEffect(() => {
+    const update = () => {
+      if (!wrapperRef.current) return;
+      const w = wrapperRef.current.offsetWidth;
+      setScale(w / CANVAS_W);
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    if (wrapperRef.current) ro.observe(wrapperRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  const currentH = treeHidden ? COLLAPSED_H : CANVAS_H;
+
   return (
     <div
-      className="relative mx-auto"
-      style={{ width: CANVAS_W, height: treeHidden ? COLLAPSED_H : CANVAS_H }}
+      ref={wrapperRef}
+      style={{ width: "100%", height: currentH * scale }}
+      className="relative overflow-hidden"
+    >
+    <div
+      className="relative origin-top-left"
+      style={{
+        width: CANVAS_W,
+        height: currentH,
+        transform: `scale(${scale})`,
+      }}
     >
       {!treeHidden && (
       <svg
@@ -140,6 +169,20 @@ export default function FairTree() {
       <ScenarioTable x={TABLE.x} y={TABLE.y} width={TABLE.width} />
 
       <div
+        className="absolute text-base font-semibold text-ink whitespace-nowrap -translate-x-1/2"
+        style={{ top: MATERIALITY_LABEL_Y, left: TABLE.x + TABLE.width / 2 }}
+      >
+        Materiality Inputs
+      </div>
+
+      <div
+        className="absolute"
+        style={{ top: MATERIALITY_Y, left: TABLE.x, width: TABLE.width }}
+      >
+        <MaterialityInput />
+      </div>
+
+      <div
         className="absolute"
         style={{ top: TREE_LABEL_Y - 2, left: TABLE.x + 20 }}
       >
@@ -161,7 +204,7 @@ export default function FairTree() {
 
       {!treeHidden && (
         <>
-          <TreeNode title="Risk"                   kind="root"   {...POS.risk} width={220} height={60} rollup={fmtUsd(risk) + " / yr"} />
+          <TreeNode title="Risk"                   kind="root"   {...POS.risk} width={220} height={60} rollup={fmtUsd(risk) + " / yr"} key="risk-node" />
           <TreeNode title="Loss Event Frequency"   kind="branch" {...POS.lef}  rollup={fmtCount(lef) + " / yr"} />
           <TreeNode title="Loss Event Magnitude"   kind="branch" {...POS.lm}   rollup={fmtUsd(lm)} />
           <TreeNode title="Threat Event Frequency" kind="branch" {...POS.tef}  rollup={fmtCount(tef) + " / yr"} />
@@ -183,6 +226,7 @@ export default function FairTree() {
           </div>
         </>
       )}
+    </div>
     </div>
   );
 }

--- a/risk-calculator/frontend/src/components/FairTree.tsx
+++ b/risk-calculator/frontend/src/components/FairTree.tsx
@@ -1,0 +1,188 @@
+import { useStore } from "../lib/state";
+import {
+  fmtCount,
+  fmtPct,
+  fmtUsd,
+  rollupLef,
+  rollupLm,
+  rollupRisk,
+  rollupSecondaryLoss,
+  rollupTef,
+  vulnerabilityFromGrid,
+} from "../lib/compute";
+import TreeNode from "./TreeNode";
+import ScenarioTable from "./ScenarioTable";
+import Toggle from "./Toggle";
+
+const CANVAS_W = 1570;
+const CANVAS_H = 740;
+const COLLAPSED_H = 200;
+
+const SCOPE_LABEL_Y = 8;
+const TABLE = { x: 165, y: 44, width: 1240, height: 80 };
+const TREE_LABEL_Y = 152;
+
+const POS = {
+  risk:    { x: 785,  y: 230 },
+  lef:     { x: 460,  y: 360 },
+  lm:      { x: 1110, y: 360 },
+  tef:     { x: 215,  y: 500 },
+  vuln:    { x: 705,  y: 500 },
+  pl:      { x: 995,  y: 500 },
+  sl:      { x: 1225, y: 500 },
+  cf:      { x: 105,  y: 650 },
+  poa:     { x: 325,  y: 650 },
+  tc:      { x: 595,  y: 650 },
+  rs:      { x: 815,  y: 650 },
+  slef:    { x: 1115, y: 650 },
+  slm:     { x: 1335, y: 650 },
+} as const;
+
+type Op = "x" | "+" | "MC";
+
+const EDGES: { from: keyof typeof POS; to: keyof typeof POS }[] = [
+  { from: "risk", to: "lef" },
+  { from: "risk", to: "lm"  },
+  { from: "lef",  to: "tef" },
+  { from: "lef",  to: "vuln" },
+  { from: "tef",  to: "cf"  },
+  { from: "tef",  to: "poa" },
+  { from: "vuln", to: "tc"  },
+  { from: "vuln", to: "rs" },
+  { from: "lm",   to: "pl"  },
+  { from: "lm",   to: "sl" },
+  { from: "sl",   to: "slef" },
+  { from: "sl",   to: "slm" },
+];
+
+const SIBLING_OPS: { left: keyof typeof POS; right: keyof typeof POS; op: Op }[] = [
+  { left: "lef",  right: "lm",   op: "x" },
+  { left: "tef",  right: "vuln", op: "x" },
+  { left: "cf",   right: "poa",  op: "x" },
+  { left: "tc",   right: "rs",   op: "MC" },
+  { left: "pl",   right: "sl",   op: "+" },
+  { left: "slef", right: "slm",  op: "x" },
+];
+
+export default function FairTree() {
+  const inputs = useStore((s) => s.inputs);
+  const treeHidden = useStore((s) => s.treeHidden);
+  const setTreeHidden = useStore((s) => s.setTreeHidden);
+
+  const tef = rollupTef(inputs.contactFrequency, inputs.probabilityOfAction);
+  const vuln = vulnerabilityFromGrid(inputs.threatCapability, inputs.resistanceStrength);
+  const lef = rollupLef(tef, vuln);
+  const sl = rollupSecondaryLoss(inputs.secondaryLossFrequency, inputs.secondaryLossMagnitude);
+  const lm = rollupLm(inputs.primaryLoss, sl);
+  const risk = rollupRisk(lef, lm);
+
+  return (
+    <div
+      className="relative mx-auto"
+      style={{ width: CANVAS_W, height: treeHidden ? COLLAPSED_H : CANVAS_H }}
+    >
+      {!treeHidden && (
+      <svg
+        className="absolute inset-0 pointer-events-none"
+        width={CANVAS_W}
+        height={CANVAS_H}
+      >
+        {EDGES.map((e, i) => {
+          const a = POS[e.from];
+          const b = POS[e.to];
+          const midY = (a.y + b.y) / 2;
+          const halfH = (k: keyof typeof POS) => (k === "risk" ? 30 : 40);
+          const d = `M ${a.x} ${a.y + halfH(e.from)} C ${a.x} ${midY}, ${b.x} ${midY}, ${b.x} ${b.y - halfH(e.to)}`;
+          return (
+            <path
+              key={i}
+              d={d}
+              stroke="#000000"
+              strokeWidth="1.5"
+              fill="none"
+            />
+          );
+        })}
+        {SIBLING_OPS.map((s, i) => {
+          const a = POS[s.left];
+          const b = POS[s.right];
+          const cx = (a.x + b.x) / 2;
+          const cy = (a.y + b.y) / 2;
+          const isMc = s.op === "MC";
+          const w = isMc ? 32 : 24;
+          const h = 24;
+          return (
+            <g key={i} transform={`translate(${cx - w / 2},${cy - h / 2})`}>
+              <rect width={w} height={h} rx="4" fill="#ffffff" stroke="#000000" />
+              <text
+                x={w / 2}
+                y={16}
+                textAnchor="middle"
+                fontSize={isMc ? 10 : 14}
+                fontWeight="700"
+                fill="#000000"
+              >
+                {s.op === "x" ? "×" : s.op}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      )}
+
+      <div
+        className="absolute text-base font-semibold text-ink whitespace-nowrap -translate-x-1/2"
+        style={{ top: SCOPE_LABEL_Y, left: TABLE.x + TABLE.width / 2 }}
+      >
+        Scope Table
+      </div>
+
+      <ScenarioTable x={TABLE.x} y={TABLE.y} width={TABLE.width} />
+
+      <div
+        className="absolute"
+        style={{ top: TREE_LABEL_Y - 2, left: TABLE.x + 20 }}
+      >
+        <Toggle
+          label="Hide tree"
+          on={treeHidden}
+          onChange={(v) => setTreeHidden(v)}
+        />
+      </div>
+
+      {!treeHidden && (
+        <div
+          className="absolute text-base font-semibold text-ink whitespace-nowrap -translate-x-1/2"
+          style={{ top: TREE_LABEL_Y, left: POS.risk.x }}
+        >
+          Factor Analysis Tree
+        </div>
+      )}
+
+      {!treeHidden && (
+        <>
+          <TreeNode title="Risk"                   kind="root"   {...POS.risk} width={220} height={60} rollup={fmtUsd(risk) + " / yr"} />
+          <TreeNode title="Loss Event Frequency"   kind="branch" {...POS.lef}  rollup={fmtCount(lef) + " / yr"} />
+          <TreeNode title="Loss Event Magnitude"   kind="branch" {...POS.lm}   rollup={fmtUsd(lm)} />
+          <TreeNode title="Threat Event Frequency" kind="branch" {...POS.tef}  rollup={fmtCount(tef) + " / yr"} />
+          <TreeNode title="Vulnerability"          kind="branch" {...POS.vuln} rollup={fmtPct(vuln)} />
+          <TreeNode title="Primary Loss"           kind="leaf"   inputKey="primaryLoss"            {...POS.pl}  rollup={fmtUsd(inputs.primaryLoss.likely)} />
+          <TreeNode title="Secondary Loss"         kind="branch" {...POS.sl}   rollup={fmtUsd(sl)} />
+          <TreeNode title="Contact Frequency"      kind="leaf"   inputKey="contactFrequency"       {...POS.cf}  rollup={fmtCount(inputs.contactFrequency.likely) + " / yr"} />
+          <TreeNode title="Probability of Action"  kind="leaf"   inputKey="probabilityOfAction"    {...POS.poa} rollup={fmtPct(inputs.probabilityOfAction.likely)} />
+          <TreeNode title="Threat Capability"      kind="leaf"   inputKey="threatCapability"       {...POS.tc}  rollup={fmtPct(inputs.threatCapability.likely)} />
+          <TreeNode title="Resistance Strength"    kind="leaf"   inputKey="resistanceStrength"     {...POS.rs}  rollup={fmtPct(inputs.resistanceStrength.likely)} />
+          <TreeNode title="Sec. Loss Frequency"    kind="leaf"   inputKey="secondaryLossFrequency" {...POS.slef} rollup={fmtPct(inputs.secondaryLossFrequency.likely)} />
+          <TreeNode title="Sec. Loss Magnitude"    kind="leaf"   inputKey="secondaryLossMagnitude" {...POS.slm}  rollup={fmtUsd(inputs.secondaryLossMagnitude.likely)} />
+
+          <div
+            className="absolute text-[11px] italic text-ink"
+            style={{ left: 20, bottom: 12 }}
+          >
+            *Open FAIR<sup className="text-[7px] relative -top-1 ml-px">TM</sup> is a trademark of the Open Group
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/risk-calculator/frontend/src/components/Histogram.tsx
+++ b/risk-calculator/frontend/src/components/Histogram.tsx
@@ -1,0 +1,53 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import { fmtUsd, fmtUsdShort } from "../lib/compute";
+
+type Props = {
+  counts: number[];
+  bins: number[];
+  materiality?: number | null;
+};
+
+export default function Histogram({ counts, bins, materiality }: Props) {
+  const data = counts.map((c, i) => ({
+    bin: (bins[i] + bins[i + 1]) / 2,
+    count: c,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <BarChart data={data} margin={{ top: 8, right: 8, bottom: 4, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis
+          dataKey="bin"
+          tickFormatter={(v) => fmtUsdShort(v)}
+          tick={{ fontSize: 10, fill: "#000" }}
+          stroke="#9ca3af"
+        />
+        <YAxis tick={{ fontSize: 10, fill: "#000" }} stroke="#9ca3af" />
+        <Tooltip
+          formatter={(v: number) => v.toLocaleString()}
+          labelFormatter={(v: number) => `Loss: ${fmtUsd(v)}`}
+          contentStyle={{ fontSize: 11 }}
+        />
+        <Bar dataKey="count" fill="#1d4ed8" />
+        {materiality && (
+          <ReferenceLine
+            x={materiality}
+            stroke="#000"
+            strokeDasharray="4 2"
+            label={{ value: "materiality", position: "top", fill: "#000", fontSize: 10 }}
+          />
+        )}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/risk-calculator/frontend/src/components/Histogram.tsx
+++ b/risk-calculator/frontend/src/components/Histogram.tsx
@@ -14,25 +14,44 @@ type Props = {
   counts: number[];
   bins: number[];
   materiality?: number | null;
+  onHover?: (text: string | null) => void;
 };
 
-export default function Histogram({ counts, bins, materiality }: Props) {
+export default function Histogram({ counts, bins, materiality, onHover }: Props) {
   const data = counts.map((c, i) => ({
     bin: (bins[i] + bins[i + 1]) / 2,
+    binLow: bins[i],
+    binHigh: bins[i + 1],
     count: c,
   }));
+  const total = counts.reduce((a, b) => a + b, 0);
 
   return (
-    <ResponsiveContainer width="100%" height={220}>
-      <BarChart data={data} margin={{ top: 8, right: 8, bottom: 4, left: 0 }}>
+    <ResponsiveContainer width="100%" height={280}>
+      <BarChart
+        data={data}
+        margin={{ top: 10, right: 10, bottom: 8, left: 8 }}
+        onMouseMove={(s: any) => {
+          if (s && s.activePayload && s.activePayload.length) {
+            const d = s.activePayload[0].payload;
+            const pct = total > 0 ? ((d.count / total) * 100).toFixed(1) : "0";
+            onHover?.(
+              `${pct} percent of simulated years produced an annual loss between ${fmtUsd(
+                d.binLow
+              )} and ${fmtUsd(d.binHigh)}.`
+            );
+          }
+        }}
+        onMouseLeave={() => onHover?.(null)}
+      >
         <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
         <XAxis
           dataKey="bin"
           tickFormatter={(v) => fmtUsdShort(v)}
-          tick={{ fontSize: 10, fill: "#000" }}
-          stroke="#9ca3af"
+          tick={{ fontSize: 13, fill: "#000" }}
+          stroke="#000"
         />
-        <YAxis tick={{ fontSize: 10, fill: "#000" }} stroke="#9ca3af" />
+        <YAxis tick={{ fontSize: 13, fill: "#000" }} stroke="#000" />
         <Tooltip
           formatter={(v: number) => v.toLocaleString()}
           labelFormatter={(v: number) => `Loss: ${fmtUsd(v)}`}

--- a/risk-calculator/frontend/src/components/InputTable.tsx
+++ b/risk-calculator/frontend/src/components/InputTable.tsx
@@ -1,0 +1,143 @@
+import * as Slider from "@radix-ui/react-slider";
+import { InputKey, INPUT_META, useStore } from "../lib/state";
+
+const ROWS: { step: number; key: InputKey; unit: string }[] = [
+  { step: 1, key: "contactFrequency",       unit: "per year"     },
+  { step: 2, key: "probabilityOfAction",    unit: "percent"      },
+  { step: 3, key: "threatCapability",       unit: "percent"      },
+  { step: 4, key: "resistanceStrength",     unit: "percent"      },
+  { step: 5, key: "primaryLoss",            unit: "USD"          },
+  { step: 6, key: "secondaryLossFrequency", unit: "percent"      },
+  { step: 7, key: "secondaryLossMagnitude", unit: "USD"          },
+];
+
+const isDollar = (k: InputKey) =>
+  k === "primaryLoss" || k === "secondaryLossMagnitude";
+
+const isPercent = (k: InputKey) =>
+  k === "probabilityOfAction" ||
+  k === "threatCapability" ||
+  k === "resistanceStrength" ||
+  k === "secondaryLossFrequency";
+
+function fmtForUnit(key: InputKey, v: number): string {
+  const rounded = Math.round(isPercent(key) ? v * 100 : v);
+  if (isDollar(key)) return `$${rounded.toLocaleString("en-US")}`;
+  if (isPercent(key)) return `${rounded}%`;
+  return `${rounded}`;
+}
+
+function parseForUnit(key: InputKey, str: string): number | null {
+  const cleaned = str.replace(/[^0-9.-]/g, "");
+  if (cleaned === "" || cleaned === "-") return 0;
+  const n = parseFloat(cleaned);
+  if (!Number.isFinite(n)) return null;
+  return isPercent(key) ? n / 100 : n;
+}
+
+const LABELS: Record<InputKey, string> = {
+  contactFrequency:       "Contact Frequency",
+  probabilityOfAction:    "Probability of Action",
+  threatCapability:       "Threat Capability",
+  resistanceStrength:     "Resistance Strength",
+  primaryLoss:            "Primary Loss",
+  secondaryLossFrequency: "Secondary Loss Frequency",
+  secondaryLossMagnitude: "Secondary Loss Magnitude",
+};
+
+export default function InputTable() {
+  const inputs = useStore((s) => s.inputs);
+  const baselines = useStore((s) => s.baselines);
+  const rationales = useStore((s) => s.rationales);
+  const setLikely = useStore((s) => s.setLikelyProportional);
+  const setRationale = useStore((s) => s.setRationale);
+  const tableFrozen = useStore((s) => s.tableFrozen);
+
+  const thBase =
+    "border border-ink px-3 py-2 text-sm font-semibold text-ink bg-panel-grey";
+  const thSticky = tableFrozen ? " sticky top-0 z-10" : "";
+
+  return (
+    <div
+      className={
+        "rounded-xl border-2 border-ink bg-canvas " +
+        (tableFrozen ? "max-h-[460px] overflow-y-auto" : "overflow-hidden")
+      }
+    >
+      <table className="w-full border-collapse table-fixed">
+        <thead>
+          <tr>
+            <th className={`${thBase}${thSticky} w-[64px]`}>Step</th>
+            <th className={`${thBase}${thSticky} w-[200px]`}>Factor</th>
+            <th className={`${thBase}${thSticky} w-[150px]`}>Factor Baseline</th>
+            <th className={`${thBase}${thSticky} w-[160px]`}>Factor Input</th>
+            <th className={`${thBase}${thSticky} w-[140px]`}>Unit</th>
+            <th className={`${thBase}${thSticky}`}>Input Rationale</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ROWS.map(({ step, key, unit }) => {
+            const label = LABELS[key];
+            const baseline = baselines[key].likely;
+            const current = inputs[key].likely;
+            return (
+              <tr key={key} className="border-b border-ink last:border-0">
+                <td className="border border-ink px-3 py-4 text-sm text-ink text-center font-mono align-middle">
+                  {step}
+                </td>
+                <td className="border border-ink px-3 py-4 text-sm text-ink align-middle">
+                  {label}
+                </td>
+                <td className="border border-ink px-3 py-4 text-sm text-ink text-right font-mono align-middle">
+                  {fmtForUnit(key, baseline)}
+                </td>
+                <td className="border border-ink p-0 align-middle">
+                  <div className="px-3 py-4 flex flex-col">
+                    <div aria-hidden="true" style={{ height: 28 }} />
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      value={fmtForUnit(key, current)}
+                      onChange={(e) => {
+                        const parsed = parseForUnit(key, e.target.value);
+                        if (parsed !== null) setLikely(key, parsed);
+                      }}
+                      className="w-full text-sm font-bold font-mono text-input-blue bg-canvas text-right rounded ring-2 ring-input-blue/40 px-2 py-1 focus:outline-none focus:ring-input-blue"
+                    />
+                    <div style={{ height: 12 }} />
+                    <Slider.Root
+                      className="relative flex items-center w-full h-4 select-none touch-none"
+                      min={INPUT_META[key].bound[0]}
+                      max={INPUT_META[key].bound[1]}
+                      step={INPUT_META[key].step}
+                      value={[current]}
+                      onValueChange={([v]) => setLikely(key, v)}
+                    >
+                      <Slider.Track className="bg-button-grey relative grow rounded-full h-1">
+                        <Slider.Range className="absolute bg-dial-grey rounded-full h-full" />
+                      </Slider.Track>
+                      <Slider.Thumb className="block w-3 h-3 bg-dial-grey border border-ink rounded-full focus:outline-none focus:ring-2 focus:ring-dial-grey/40" />
+                    </Slider.Root>
+                  </div>
+                </td>
+                <td className="border border-ink px-3 py-4 text-sm text-ink align-middle">
+                  {unit}
+                </td>
+                <td className="border border-ink p-0 align-middle">
+                  <textarea
+                    value={rationales[key]}
+                    onChange={(e) => setRationale(key, e.target.value)}
+                    placeholder="enter rationale"
+                    rows={1}
+                    style={{ maxHeight: "7.5em" }}
+                    className="w-full px-3 py-4 text-sm font-bold text-input-blue bg-canvas placeholder:font-normal placeholder:text-ink/40 focus:outline-none focus:ring-2 focus:ring-input-blue/40 resize-none overflow-y-auto block leading-snug"
+                  />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/risk-calculator/frontend/src/components/MaterialityInput.tsx
+++ b/risk-calculator/frontend/src/components/MaterialityInput.tsx
@@ -1,0 +1,151 @@
+import * as Popover from "@radix-ui/react-popover";
+import { useStore } from "../lib/state";
+import citationsRaw from "../data/citations.json";
+
+type Citation = { id: string; apa: string; url: string };
+const CITES: Record<string, Citation> = citationsRaw as any;
+
+export const METRIC_OPTIONS: { value: "manual" | "market_cap" | "revenue" | "net_income"; label: string; defaultPct: number }[] = [
+  { value: "manual",     label: "Manual",                defaultPct: 100 },
+  { value: "market_cap", label: "Market Capitalization", defaultPct: 0.5 },
+  { value: "revenue",    label: "Annual Revenue",        defaultPct: 1.0 },
+  { value: "net_income", label: "Net Income",            defaultPct: 5.0 },
+];
+
+function fmtUsd(v: number): string {
+  return `$${Math.round(v).toLocaleString("en-US")}`;
+}
+
+function parseInput(str: string): number | null {
+  const cleaned = str.replace(/[^0-9.-]/g, "");
+  if (cleaned === "" || cleaned === "-") return 0;
+  const n = parseFloat(cleaned);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function computedMateriality(m: ReturnType<typeof useStore.getState>["materiality"]): number {
+  if (m.metric === "manual") return m.value;
+  return m.value * (m.threshold / 100);
+}
+
+const REFERENCED_IDS = ["sec-cyber-rule-2023", "sec-sab-99"];
+
+export default function MaterialityInput() {
+  const materiality = useStore((s) => s.materiality);
+  const setMateriality = useStore((s) => s.setMateriality);
+
+  const isManual = materiality.metric === "manual";
+  const computed = computedMateriality(materiality);
+
+  return (
+    <table className="w-full border-2 border-ink border-collapse table-fixed bg-canvas">
+      <thead>
+        <tr>
+          <th className="border border-ink px-2 py-1.5 text-[12px] font-semibold text-ink text-center bg-canvas">
+            Materiality Basis{" "}
+            <Popover.Root>
+              <Popover.Trigger asChild>
+                <button
+                  type="button"
+                  className="text-input-blue underline hover:no-underline font-normal"
+                >
+                  (references)
+                </button>
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Content
+                  side="bottom"
+                  align="start"
+                  sideOffset={6}
+                  className="z-50 w-[420px] rounded-xl border-2 border-ink bg-canvas p-4 shadow-xl text-xs text-ink"
+                >
+                  <div className="font-semibold mb-2">References</div>
+                  <ol className="space-y-2 list-decimal pl-4">
+                    {REFERENCED_IDS.map((id) => {
+                      const c = CITES[id];
+                      if (!c) return null;
+                      return (
+                        <li key={id} className="leading-snug">
+                          <a
+                            href={c.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline hover:no-underline"
+                          >
+                            {c.apa}
+                          </a>
+                        </li>
+                      );
+                    })}
+                  </ol>
+                  <Popover.Arrow className="fill-ink" />
+                </Popover.Content>
+              </Popover.Portal>
+            </Popover.Root>
+          </th>
+          <th className="border border-ink px-2 py-1.5 text-[12px] font-semibold text-ink text-center bg-canvas">
+            Reference Value
+          </th>
+          <th className="border border-ink px-2 py-1.5 text-[12px] font-semibold text-ink text-center bg-canvas">
+            Percent Threshold
+          </th>
+          <th className="border border-ink px-2 py-1.5 text-[12px] font-semibold text-ink text-center bg-canvas">
+            Computed Materiality
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td className="border border-ink p-0">
+            <select
+              value={materiality.metric}
+              onChange={(e) => {
+                const m = e.target.value as typeof materiality.metric;
+                const found = METRIC_OPTIONS.find((o) => o.value === m);
+                setMateriality({ metric: m, threshold: found?.defaultPct ?? materiality.threshold });
+              }}
+              className="w-full px-2 py-2 text-[13px] font-bold text-input-blue bg-canvas focus:outline-none focus:ring-2 focus:ring-input-blue/40"
+            >
+              {METRIC_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </td>
+          <td className="border border-ink p-0">
+            <input
+              type="text"
+              inputMode="numeric"
+              value={fmtUsd(materiality.value)}
+              onChange={(e) => {
+                const v = parseInput(e.target.value);
+                if (v !== null) setMateriality({ value: v });
+              }}
+              className="w-full px-2 py-2 text-[13px] font-bold text-input-blue bg-canvas text-center focus:outline-none focus:ring-2 focus:ring-input-blue/40"
+            />
+          </td>
+          <td className="border border-ink p-0">
+            {isManual ? (
+              <div className="w-full px-2 py-2 text-[13px] text-ink text-center">—</div>
+            ) : (
+              <input
+                type="text"
+                inputMode="decimal"
+                value={`${materiality.threshold}%`}
+                onChange={(e) => {
+                  const cleaned = e.target.value.replace(/[^0-9.]/g, "");
+                  const v = parseFloat(cleaned);
+                  if (Number.isFinite(v)) setMateriality({ threshold: v });
+                  else if (cleaned === "") setMateriality({ threshold: 0 });
+                }}
+                className="w-full px-2 py-2 text-[13px] font-bold text-input-blue bg-canvas text-center focus:outline-none focus:ring-2 focus:ring-input-blue/40"
+              />
+            )}
+          </td>
+          <td className="border border-ink px-2 py-2 text-[13px] font-bold text-input-pink text-center">
+            {fmtUsd(computed)}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}

--- a/risk-calculator/frontend/src/components/References.tsx
+++ b/risk-calculator/frontend/src/components/References.tsx
@@ -1,0 +1,56 @@
+import citationsRaw from "../data/citations.json";
+import sectorsRaw from "../data/sector_defaults.json";
+import { useStore } from "../lib/state";
+
+type Citation = { id: string; apa: string; url: string };
+
+const CITATIONS: Citation[] = Object.values(citationsRaw) as Citation[];
+const META: any = (sectorsRaw as any)._meta;
+
+export default function References() {
+  const open = useStore((s) => s.referencesOpen);
+  const setOpen = useStore((s) => s.setReferencesOpen);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-ink/40 flex items-center justify-center p-6 no-print"
+      onClick={() => setOpen(false)}
+    >
+      <div
+        className="bg-canvas border-2 border-ink rounded-xl max-w-3xl w-full max-h-[80vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-5 py-3 border-b-2 border-ink flex items-center justify-between">
+          <h2 className="text-lg font-bold text-ink">References</h2>
+          <button
+            onClick={() => setOpen(false)}
+            className="px-3 py-1 bg-button-grey border border-ink rounded text-sm font-semibold text-ink"
+          >
+            Close
+          </button>
+        </div>
+        <div className="px-5 py-4 space-y-3">
+          <p className="text-xs italic text-ink">
+            Data vintage: {META?.vintage ?? "n/a"}. {META?.disclaimer ?? ""}
+          </p>
+          <ol className="space-y-2 text-sm text-ink">
+            {CITATIONS.sort((a, b) => a.apa.localeCompare(b.apa)).map((c) => (
+              <li key={c.id} className="leading-snug">
+                <a
+                  href={c.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:no-underline"
+                >
+                  {c.apa}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/risk-calculator/frontend/src/components/ResultsView.tsx
+++ b/risk-calculator/frontend/src/components/ResultsView.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { SimResult } from "../lib/state";
+import SummaryStats from "./SummaryStats";
+import Histogram from "./Histogram";
+import ExceedanceCurve from "./ExceedanceCurve";
+
+type Props = { result: SimResult };
+
+export default function ResultsView({ result }: Props) {
+  const [histHover, setHistHover] = useState<string | null>(null);
+  const [exHover, setExHover] = useState<string | null>(null);
+
+  return (
+    <div className="space-y-4">
+      <SummaryStats
+        summary={result.summary}
+        iterations={result.iterations}
+      />
+
+      <div className="grid lg:grid-cols-[1fr_2fr] gap-4">
+        <div className="rounded-xl border border-ink bg-canvas p-3 flex flex-col">
+          <h4 className="text-sm font-semibold text-ink mb-2">
+            Distribution insight
+          </h4>
+          <p className="text-sm text-ink flex-1">
+            {histHover ?? "Hover over a bar to see how often that loss range appears in the simulation."}
+          </p>
+        </div>
+        <div className="rounded-xl border border-ink bg-canvas p-3">
+          <h3 className="text-sm font-semibold text-ink mb-2">
+            Annualized Loss Expectancy distribution
+          </h3>
+          <Histogram
+            counts={result.histogram.counts}
+            bins={result.histogram.bins}
+            onHover={setHistHover}
+          />
+        </div>
+      </div>
+
+      <div className="grid lg:grid-cols-[1fr_2fr] gap-4">
+        <div className="rounded-xl border border-ink bg-canvas p-3 flex flex-col">
+          <h4 className="text-sm font-semibold text-ink mb-2">
+            Exceedance insight
+          </h4>
+          <p className="text-sm text-ink flex-1">
+            {exHover ?? "Hover over the curve to see the probability of exceeding a given annual loss."}
+          </p>
+        </div>
+        <div className="rounded-xl border border-ink bg-canvas p-3">
+          <h3 className="text-sm font-semibold text-ink mb-2">
+            Loss exceedance curve
+          </h3>
+          <ExceedanceCurve
+            values={result.exceedance.values}
+            probabilities={result.exceedance.probabilities}
+            onHover={setExHover}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/risk-calculator/frontend/src/components/ResultsView.tsx
+++ b/risk-calculator/frontend/src/components/ResultsView.tsx
@@ -1,20 +1,32 @@
 import { useState } from "react";
-import { SimResult } from "../lib/state";
+import { SimResult, useStore } from "../lib/state";
 import SummaryStats from "./SummaryStats";
 import Histogram from "./Histogram";
 import ExceedanceCurve from "./ExceedanceCurve";
+import { computedMateriality } from "./MaterialityInput";
 
 type Props = { result: SimResult };
 
 export default function ResultsView({ result }: Props) {
   const [histHover, setHistHover] = useState<string | null>(null);
   const [exHover, setExHover] = useState<string | null>(null);
+  const materiality = useStore((s) => s.materiality);
+  const matValue = computedMateriality(materiality);
+
+  const totalCount = result.histogram.counts.reduce((a, b) => a + b, 0);
+  const exceedCount = result.histogram.counts.reduce(
+    (acc, c, i) => acc + (result.histogram.bins[i] >= matValue ? c : 0),
+    0
+  );
+  const probExceed = totalCount > 0 ? (exceedCount / totalCount) * 100 : 0;
 
   return (
     <div className="space-y-4">
       <SummaryStats
         summary={result.summary}
         iterations={result.iterations}
+        materiality={matValue}
+        probExceed={probExceed}
       />
 
       <div className="grid lg:grid-cols-[1fr_2fr] gap-4">
@@ -33,6 +45,7 @@ export default function ResultsView({ result }: Props) {
           <Histogram
             counts={result.histogram.counts}
             bins={result.histogram.bins}
+            materiality={matValue}
             onHover={setHistHover}
           />
         </div>
@@ -54,6 +67,7 @@ export default function ResultsView({ result }: Props) {
           <ExceedanceCurve
             values={result.exceedance.values}
             probabilities={result.exceedance.probabilities}
+            materiality={matValue}
             onHover={setExHover}
           />
         </div>

--- a/risk-calculator/frontend/src/components/ScenarioSummary.tsx
+++ b/risk-calculator/frontend/src/components/ScenarioSummary.tsx
@@ -1,5 +1,6 @@
 import { InputKey, ScenarioMetaKey, useStore } from "../lib/state";
 import { simulate } from "../lib/api";
+import { computedMateriality, METRIC_OPTIONS } from "./MaterialityInput";
 
 const SCOPE_ROWS: { key: ScenarioMetaKey; label: string }[] = [
   { key: "scenarioNumber",  label: "Scenario Number" },
@@ -40,8 +41,13 @@ export default function ScenarioSummary() {
   const inputs = useStore((s) => s.inputs);
   const iterations = useStore((s) => s.iterations);
   const running = useStore((s) => s.running);
+  const materiality = useStore((s) => s.materiality);
   const setResult = useStore((s) => s.setResult);
   const setRunning = useStore((s) => s.setRunning);
+
+  const matComputed = computedMateriality(materiality);
+  const basisLabel =
+    METRIC_OPTIONS.find((o) => o.value === materiality.metric)?.label ?? materiality.metric;
 
   const runScenario = async (alsoPrint: boolean) => {
     setRunning(true);
@@ -111,6 +117,41 @@ export default function ScenarioSummary() {
                 {fmt(key, inputs[key].likely)}
               </td>
             ))}
+          </tr>
+        </tbody>
+      </table>
+
+      <table className="w-full border-collapse border-2 border-ink table-fixed bg-canvas">
+        <thead>
+          <tr>
+            <th className="border border-ink px-2 py-2 text-sm font-bold text-ink bg-panel-grey text-center leading-tight">
+              Materiality Basis
+            </th>
+            <th className="border border-ink px-2 py-2 text-sm font-bold text-ink bg-panel-grey text-center leading-tight">
+              Reference Value
+            </th>
+            <th className="border border-ink px-2 py-2 text-sm font-bold text-ink bg-panel-grey text-center leading-tight">
+              Percent Threshold
+            </th>
+            <th className="border border-ink px-2 py-2 text-sm font-bold text-ink bg-panel-grey text-center leading-tight">
+              Computed Materiality
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border border-ink px-2 py-2 text-sm font-bold text-ink text-center">
+              {basisLabel}
+            </td>
+            <td className="border border-ink px-2 py-2 text-sm font-bold text-ink text-center">
+              {`$${Math.round(materiality.value).toLocaleString("en-US")}`}
+            </td>
+            <td className="border border-ink px-2 py-2 text-sm font-bold text-ink text-center">
+              {materiality.metric === "manual" ? "—" : `${materiality.threshold}%`}
+            </td>
+            <td className="border border-ink px-2 py-2 text-sm font-bold text-ink text-center">
+              {`$${Math.round(matComputed).toLocaleString("en-US")}`}
+            </td>
           </tr>
         </tbody>
       </table>

--- a/risk-calculator/frontend/src/components/ScenarioSummary.tsx
+++ b/risk-calculator/frontend/src/components/ScenarioSummary.tsx
@@ -1,0 +1,136 @@
+import { InputKey, ScenarioMetaKey, useStore } from "../lib/state";
+import { simulate } from "../lib/api";
+
+const SCOPE_ROWS: { key: ScenarioMetaKey; label: string }[] = [
+  { key: "scenarioNumber",  label: "Scenario Number" },
+  { key: "asset",           label: "Asset" },
+  { key: "threatCommunity", label: "Threat Community" },
+  { key: "threatType",      label: "Threat Type" },
+  { key: "effect",          label: "Effect" },
+];
+
+const FACTOR_ROWS: { key: InputKey; label: string }[] = [
+  { key: "contactFrequency",       label: "Contact Frequency" },
+  { key: "probabilityOfAction",    label: "Probability of Action" },
+  { key: "threatCapability",       label: "Threat Capability" },
+  { key: "resistanceStrength",     label: "Resistance Strength" },
+  { key: "primaryLoss",            label: "Primary Loss" },
+  { key: "secondaryLossFrequency", label: "Secondary Loss Frequency" },
+  { key: "secondaryLossMagnitude", label: "Secondary Loss Magnitude" },
+];
+
+const isDollar = (k: InputKey) =>
+  k === "primaryLoss" || k === "secondaryLossMagnitude";
+
+const isPercent = (k: InputKey) =>
+  k === "probabilityOfAction" ||
+  k === "threatCapability" ||
+  k === "resistanceStrength" ||
+  k === "secondaryLossFrequency";
+
+function fmt(key: InputKey, v: number): string {
+  const r = Math.round(isPercent(key) ? v * 100 : v);
+  if (isDollar(key)) return `$${r.toLocaleString("en-US")}`;
+  if (isPercent(key)) return `${r}%`;
+  return `${r}`;
+}
+
+export default function ScenarioSummary() {
+  const meta = useStore((s) => s.scenarioMeta);
+  const inputs = useStore((s) => s.inputs);
+  const iterations = useStore((s) => s.iterations);
+  const running = useStore((s) => s.running);
+  const setResult = useStore((s) => s.setResult);
+  const setRunning = useStore((s) => s.setRunning);
+
+  const runScenario = async (alsoPrint: boolean) => {
+    setRunning(true);
+    try {
+      const result = await simulate(inputs, iterations);
+      setResult(result);
+      if (alsoPrint) {
+        setTimeout(() => window.print(), 500);
+      }
+    } catch (err) {
+      console.error("simulate failed", err);
+      alert("Simulation failed; check the backend connection.");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <table className="w-full border-collapse border-2 border-ink table-fixed bg-canvas">
+        <thead>
+          <tr>
+            {SCOPE_ROWS.map(({ key, label }) => (
+              <th
+                key={key}
+                className="border border-ink px-2 py-2 text-sm font-bold text-ink bg-panel-grey text-center leading-tight"
+              >
+                {label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            {SCOPE_ROWS.map(({ key }) => (
+              <td
+                key={key}
+                className="border border-ink px-2 py-2 text-sm font-bold text-ink text-center truncate"
+              >
+                {meta[key] || <span className="text-ink/40 font-bold">—</span>}
+              </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+
+      <table className="w-full border-collapse border-2 border-ink table-fixed bg-canvas">
+        <thead>
+          <tr>
+            {FACTOR_ROWS.map(({ key, label }) => (
+              <th
+                key={key}
+                className="border border-ink px-2 py-2 text-sm font-bold text-ink bg-panel-grey text-center leading-tight"
+              >
+                {label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            {FACTOR_ROWS.map(({ key }) => (
+              <td
+                key={key}
+                className="border border-ink px-2 py-2 text-sm font-bold text-ink text-center"
+              >
+                {fmt(key, inputs[key].likely)}
+              </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="pt-2 flex gap-3 justify-center no-print">
+        <button
+          onClick={() => runScenario(false)}
+          disabled={running}
+          className="px-4 py-2 bg-button-grey border border-ink rounded text-ink font-semibold hover:brightness-95 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {running ? "Running..." : "Run Scenario"}
+        </button>
+        <button
+          onClick={() => runScenario(true)}
+          disabled={running}
+          className="px-4 py-2 bg-button-grey border border-ink rounded text-ink font-semibold hover:brightness-95 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {running ? "Running..." : "Run Scenario and PDF"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/risk-calculator/frontend/src/components/ScenarioTable.tsx
+++ b/risk-calculator/frontend/src/components/ScenarioTable.tsx
@@ -1,11 +1,29 @@
-import { ScenarioMetaKey, useStore } from "../lib/state";
+import { InputKey, ScenarioMetaKey, Triangular, useStore } from "../lib/state";
+import sectorsRaw from "../data/sector_defaults.json";
 
-const COLS: { key: ScenarioMetaKey; label: string; placeholder: string }[] = [
+type SectorEntry = {
+  id: string;
+  display_name: string;
+  defaults: Record<InputKey, Triangular>;
+};
+
+const SECTORS: Record<string, SectorEntry> = Object.fromEntries(
+  Object.entries(sectorsRaw)
+    .filter(([k]) => !k.startsWith("_"))
+    .map(([k, v]) => [k, v as SectorEntry])
+);
+
+type ScopeCol = { key: ScenarioMetaKey; label: string; placeholder: string };
+
+const TEXT_COLS_BEFORE: ScopeCol[] = [
   { key: "scenarioNumber",  label: "Scenario Number", placeholder: "e.g. SCN-001" },
-  { key: "asset",           label: "Asset",           placeholder: "e.g. Customer database" },
+];
+
+const TEXT_COLS_AFTER: ScopeCol[] = [
+  { key: "asset",           label: "Asset",            placeholder: "e.g. Customer database" },
   { key: "threatCommunity", label: "Threat Community", placeholder: "e.g. Organized crime" },
-  { key: "threatType",      label: "Threat Type",     placeholder: "e.g. Ransomware" },
-  { key: "effect",          label: "Effect",          placeholder: "e.g. Confidentiality" },
+  { key: "threatType",      label: "Threat Type",      placeholder: "e.g. Ransomware" },
+  { key: "effect",          label: "Effect",           placeholder: "e.g. Confidentiality" },
 ];
 
 type Props = { x: number; y: number; width: number };
@@ -13,6 +31,30 @@ type Props = { x: number; y: number; width: number };
 export default function ScenarioTable({ x, y, width }: Props) {
   const meta = useStore((s) => s.scenarioMeta);
   const setMeta = useStore((s) => s.setScenarioMeta);
+  const sector = useStore((s) => s.sector);
+  const setSector = useStore((s) => s.setSector);
+  const setReferencesOpen = useStore((s) => s.setReferencesOpen);
+
+  const renderTextCell = (c: ScopeCol) => (
+    <td key={c.key} className="border border-ink p-0">
+      <input
+        type="text"
+        value={meta[c.key]}
+        onChange={(e) => setMeta(c.key, e.target.value)}
+        placeholder={c.placeholder}
+        className="w-full px-2 py-2 text-[13px] font-bold text-input-blue bg-canvas placeholder:font-normal placeholder:text-ink/40 focus:outline-none focus:ring-2 focus:ring-input-blue/40"
+      />
+    </td>
+  );
+
+  const renderTextHeader = (c: ScopeCol) => (
+    <th
+      key={c.key}
+      className="border border-ink px-2 py-1.5 text-[12px] font-semibold text-ink text-center bg-canvas"
+    >
+      {c.label}
+    </th>
+  );
 
   return (
     <div
@@ -22,29 +64,46 @@ export default function ScenarioTable({ x, y, width }: Props) {
       <table className="w-full border-2 border-ink border-collapse table-fixed bg-canvas">
         <thead>
           <tr>
-            {COLS.map((c) => (
-              <th
-                key={c.key}
-                className="border border-ink px-2 py-1.5 text-[12px] font-semibold text-ink text-center bg-canvas"
+            {TEXT_COLS_BEFORE.map(renderTextHeader)}
+            <th className="border border-ink px-2 py-1.5 text-[12px] font-semibold text-ink text-center bg-canvas">
+              Industry{" "}
+              <button
+                type="button"
+                onClick={() => setReferencesOpen(true)}
+                className="text-input-blue underline hover:no-underline"
               >
-                {c.label}
-              </th>
-            ))}
+                (References)
+              </button>
+            </th>
+            {TEXT_COLS_AFTER.map(renderTextHeader)}
           </tr>
         </thead>
         <tbody>
           <tr>
-            {COLS.map((c) => (
-              <td key={c.key} className="border border-ink p-0">
-                <input
-                  type="text"
-                  value={meta[c.key]}
-                  onChange={(e) => setMeta(c.key, e.target.value)}
-                  placeholder={c.placeholder}
-                  className="w-full px-2 py-2 text-[13px] font-bold text-input-blue bg-canvas placeholder:font-normal placeholder:text-ink/40 focus:outline-none focus:ring-2 focus:ring-input-blue/40"
-                />
-              </td>
-            ))}
+            {TEXT_COLS_BEFORE.map(renderTextCell)}
+            <td className="border border-ink p-0">
+              <select
+                value={sector}
+                onChange={(e) => {
+                  const id = e.target.value;
+                  if (id === "custom") {
+                    setSector("custom", {} as Record<InputKey, Triangular>);
+                    return;
+                  }
+                  const entry = SECTORS[id];
+                  if (entry) setSector(id, entry.defaults);
+                }}
+                className="w-full px-2 py-2 text-[13px] font-bold text-input-blue bg-canvas focus:outline-none focus:ring-2 focus:ring-input-blue/40"
+              >
+                <option value="custom">— Custom —</option>
+                {Object.values(SECTORS).map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.display_name}
+                  </option>
+                ))}
+              </select>
+            </td>
+            {TEXT_COLS_AFTER.map(renderTextCell)}
           </tr>
         </tbody>
       </table>

--- a/risk-calculator/frontend/src/components/ScenarioTable.tsx
+++ b/risk-calculator/frontend/src/components/ScenarioTable.tsx
@@ -1,0 +1,53 @@
+import { ScenarioMetaKey, useStore } from "../lib/state";
+
+const COLS: { key: ScenarioMetaKey; label: string; placeholder: string }[] = [
+  { key: "scenarioNumber",  label: "Scenario Number", placeholder: "e.g. SCN-001" },
+  { key: "asset",           label: "Asset",           placeholder: "e.g. Customer database" },
+  { key: "threatCommunity", label: "Threat Community", placeholder: "e.g. Organized crime" },
+  { key: "threatType",      label: "Threat Type",     placeholder: "e.g. Ransomware" },
+  { key: "effect",          label: "Effect",          placeholder: "e.g. Confidentiality" },
+];
+
+type Props = { x: number; y: number; width: number };
+
+export default function ScenarioTable({ x, y, width }: Props) {
+  const meta = useStore((s) => s.scenarioMeta);
+  const setMeta = useStore((s) => s.setScenarioMeta);
+
+  return (
+    <div
+      className="absolute"
+      style={{ left: x, top: y, width }}
+    >
+      <table className="w-full border-2 border-ink border-collapse table-fixed bg-canvas">
+        <thead>
+          <tr>
+            {COLS.map((c) => (
+              <th
+                key={c.key}
+                className="border border-ink px-2 py-1.5 text-[12px] font-semibold text-ink text-center bg-canvas"
+              >
+                {c.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            {COLS.map((c) => (
+              <td key={c.key} className="border border-ink p-0">
+                <input
+                  type="text"
+                  value={meta[c.key]}
+                  onChange={(e) => setMeta(c.key, e.target.value)}
+                  placeholder={c.placeholder}
+                  className="w-full px-2 py-2 text-[13px] font-bold text-input-blue bg-canvas placeholder:font-normal placeholder:text-ink/40 focus:outline-none focus:ring-2 focus:ring-input-blue/40"
+                />
+              </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/risk-calculator/frontend/src/components/SummaryStats.tsx
+++ b/risk-calculator/frontend/src/components/SummaryStats.tsx
@@ -1,9 +1,14 @@
 import { fmtUsd } from "../lib/compute";
 import { SimResult } from "../lib/state";
 
-type Props = { summary: SimResult["summary"]; iterations: number };
+type Props = {
+  summary: SimResult["summary"];
+  iterations: number;
+  materiality?: number;
+  probExceed?: number;
+};
 
-export default function SummaryStats({ summary, iterations }: Props) {
+export default function SummaryStats({ summary, iterations, materiality, probExceed }: Props) {
   const rows: [string, number, string?][] = [
     ["Mean ALE", summary.mean],
     ["Median ALE", summary.median],
@@ -21,8 +26,14 @@ export default function SummaryStats({ summary, iterations }: Props) {
         percent chance of exceeding{" "}
         <span className="text-ink">{fmtUsd(summary.var_95)}</span>. The expected
         loss in the worst five percent of years averages{" "}
-        <span className="text-ink">{fmtUsd(summary.cvar_95)}</span>. Results are
-        based on {iterations.toLocaleString()} Monte Carlo iterations.
+        <span className="text-ink">{fmtUsd(summary.cvar_95)}</span>.{" "}
+        {materiality !== undefined && probExceed !== undefined && (
+          <>
+            There is a {probExceed.toFixed(1)} percent chance of exceeding the
+            materiality threshold of {fmtUsd(materiality)}.{" "}
+          </>
+        )}
+        Results are based on {iterations.toLocaleString()} Monte Carlo iterations.
       </div>
       <table className="w-full border-collapse border-2 border-ink table-fixed bg-canvas">
         <thead>

--- a/risk-calculator/frontend/src/components/SummaryStats.tsx
+++ b/risk-calculator/frontend/src/components/SummaryStats.tsx
@@ -1,0 +1,40 @@
+import { fmtUsd } from "../lib/compute";
+import { SimResult } from "../lib/state";
+
+type Props = { summary: SimResult["summary"]; iterations: number };
+
+export default function SummaryStats({ summary, iterations }: Props) {
+  const rows: [string, number, string?][] = [
+    ["Mean ALE", summary.mean],
+    ["Median ALE", summary.median],
+    ["Standard deviation", summary.std],
+    ["10th percentile", summary.p10],
+    ["90th percentile", summary.p90],
+    ["95th percentile (Value at Risk)", summary.var_95, "var"],
+    ["Conditional VaR (Expected Shortfall)", summary.cvar_95, "cvar"],
+  ];
+  return (
+    <div className="rounded-lg border border-line-grey bg-canvas">
+      <div className="px-3 py-2 border-b border-line-grey text-xs text-ink flex items-center justify-between">
+        <span>Annualized Loss Expectancy</span>
+        <span>iterations: {iterations.toLocaleString()}</span>
+      </div>
+      <table className="w-full text-sm">
+        <tbody>
+          {rows.map(([label, value, k]) => (
+            <tr key={label} className="border-b border-line-grey last:border-0">
+              <td className="px-3 py-1.5 text-ink">{label}</td>
+              <td
+                className={
+                  "px-3 py-1.5 text-right font-mono font-bold text-ink"
+                }
+              >
+                {fmtUsd(value)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/risk-calculator/frontend/src/components/SummaryStats.tsx
+++ b/risk-calculator/frontend/src/components/SummaryStats.tsx
@@ -14,25 +14,40 @@ export default function SummaryStats({ summary, iterations }: Props) {
     ["Conditional VaR (Expected Shortfall)", summary.cvar_95, "cvar"],
   ];
   return (
-    <div className="rounded-lg border border-line-grey bg-canvas">
-      <div className="px-3 py-2 border-b border-line-grey text-xs text-ink flex items-center justify-between">
-        <span>Annualized Loss Expectancy</span>
-        <span>iterations: {iterations.toLocaleString()}</span>
+    <div className="space-y-2">
+      <div className="text-sm font-bold text-ink px-1">
+        The simulation projects an average annual loss of{" "}
+        <span className="text-ink">{fmtUsd(summary.mean)}</span>, with a five
+        percent chance of exceeding{" "}
+        <span className="text-ink">{fmtUsd(summary.var_95)}</span>. The expected
+        loss in the worst five percent of years averages{" "}
+        <span className="text-ink">{fmtUsd(summary.cvar_95)}</span>. Results are
+        based on {iterations.toLocaleString()} Monte Carlo iterations.
       </div>
-      <table className="w-full text-sm">
+      <table className="w-full border-collapse border-2 border-ink table-fixed bg-canvas">
+        <thead>
+          <tr>
+            {rows.map(([label]) => (
+              <th
+                key={label}
+                className="border border-ink px-2 py-2 text-sm font-bold text-ink bg-panel-grey text-center leading-tight"
+              >
+                {label}
+              </th>
+            ))}
+          </tr>
+        </thead>
         <tbody>
-          {rows.map(([label, value, k]) => (
-            <tr key={label} className="border-b border-line-grey last:border-0">
-              <td className="px-3 py-1.5 text-ink">{label}</td>
+          <tr>
+            {rows.map(([label, value]) => (
               <td
-                className={
-                  "px-3 py-1.5 text-right font-mono font-bold text-ink"
-                }
+                key={label}
+                className="border border-ink px-2 py-2 text-sm font-bold text-ink text-center"
               >
                 {fmtUsd(value)}
               </td>
-            </tr>
-          ))}
+            ))}
+          </tr>
         </tbody>
       </table>
     </div>

--- a/risk-calculator/frontend/src/components/Toggle.tsx
+++ b/risk-calculator/frontend/src/components/Toggle.tsx
@@ -1,0 +1,30 @@
+type Props = {
+  on: boolean;
+  onChange: (next: boolean) => void;
+  label: string;
+};
+
+export default function Toggle({ on, onChange, label }: Props) {
+  return (
+    <label className="inline-flex items-center gap-2 cursor-pointer select-none">
+      <span className="text-xs font-semibold text-ink">{label}</span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={on}
+        onClick={() => onChange(!on)}
+        className={
+          "relative w-10 h-5 rounded-full border border-ink transition-colors " +
+          (on ? "bg-input-blue" : "bg-button-grey")
+        }
+      >
+        <span
+          className={
+            "absolute top-0.5 w-3.5 h-3.5 rounded-full bg-canvas border border-ink transition-all " +
+            (on ? "left-[22px]" : "left-0.5")
+          }
+        />
+      </button>
+    </label>
+  );
+}

--- a/risk-calculator/frontend/src/components/TreeNode.tsx
+++ b/risk-calculator/frontend/src/components/TreeNode.tsx
@@ -41,9 +41,26 @@ export default function TreeNode({ title, kind, inputKey, rollup, x, y, width, h
         </div>
       )}
       {rollup !== undefined && (
-        <div className="mt-1 text-[12px] text-ink whitespace-nowrap">
+        <div className="mt-1 text-[12px] text-ink whitespace-nowrap inline-flex items-center justify-center gap-1">
           <span>Input Value: </span>
           <span className="font-mono font-bold text-input-pink">{rollup}</span>
+          {kind === "leaf" && inputKey && (
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="inline-block text-ink"
+              aria-hidden="true"
+            >
+              <path d="M12 20h9" />
+              <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+            </svg>
+          )}
         </div>
       )}
     </div>

--- a/risk-calculator/frontend/src/components/TreeNode.tsx
+++ b/risk-calculator/frontend/src/components/TreeNode.tsx
@@ -1,0 +1,102 @@
+import * as Popover from "@radix-ui/react-popover";
+import { InputKey, Triangular, INPUT_META, useStore } from "../lib/state";
+import Dial from "./Dial";
+
+export type NodeKind = "root" | "branch" | "leaf";
+
+type Props = {
+  title: string;
+  kind: NodeKind;
+  inputKey?: InputKey;
+  rollup?: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+};
+
+const DEFAULT_W = 170;
+const DEFAULT_H = 80;
+
+export default function TreeNode({ title, kind, inputKey, rollup, x, y, width, height }: Props) {
+  const W = width ?? DEFAULT_W;
+  const H = height ?? DEFAULT_H;
+  const inputs = useStore((s) => s.inputs);
+  const baselines = useStore((s) => s.baselines);
+  const setLeaf = useStore((s) => s.setLeaf);
+  const resetToBaseline = useStore((s) => s.resetToBaseline);
+
+  const card = (
+    <div
+      className={
+        "absolute select-none rounded-lg border-2 border-ink px-3 py-2 bg-canvas shadow-sm transition flex flex-col items-center justify-center text-center " +
+        (kind === "leaf" ? "cursor-pointer hover:shadow-md" : "")
+      }
+      style={{ left: x - W / 2, top: y - H / 2, width: W, height: H }}
+    >
+      <div className="text-[13px] font-semibold leading-tight text-ink">{title}</div>
+      {inputKey && (
+        <div className="mt-1 text-[11px] text-ink">
+          Baseline {formatBaseline(inputKey, baselines[inputKey])}
+        </div>
+      )}
+      {rollup !== undefined && (
+        <div className="mt-1 text-[12px] text-ink whitespace-nowrap">
+          <span>Input Value: </span>
+          <span className="font-mono font-bold text-input-pink">{rollup}</span>
+        </div>
+      )}
+    </div>
+  );
+
+  if (kind !== "leaf" || !inputKey) return card;
+
+  const meta = INPUT_META[inputKey];
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>{card}</Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          side="bottom"
+          align="center"
+          sideOffset={8}
+          className="z-50 w-64 rounded-xl border border-ink bg-canvas p-4 shadow-xl"
+        >
+          <div className="mb-2">
+            <div className="text-sm font-bold text-ink">{meta.label}</div>
+            <div className="text-[11px] text-dial-grey">unit: {meta.unit}</div>
+          </div>
+          <Dial
+            value={inputs[inputKey]}
+            baseline={baselines[inputKey]}
+            bound={meta.bound}
+            step={meta.step}
+            unit={meta.unit}
+            onChange={(v: Triangular) => setLeaf(inputKey, v)}
+            onReset={() => resetToBaseline(inputKey)}
+          />
+          <Popover.Arrow className="fill-ink" />
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+function formatBaseline(key: InputKey, t: Triangular): string {
+  const v = t.likely;
+  if (key === "primaryLoss" || key === "secondaryLossMagnitude") {
+    return `$${Math.round(v).toLocaleString("en-US")}`;
+  }
+  if (
+    key === "probabilityOfAction" ||
+    key === "threatCapability" ||
+    key === "resistanceStrength" ||
+    key === "secondaryLossFrequency"
+  ) {
+    return `${Math.round(v * 100)}%`;
+  }
+  return `${Math.round(v)}`;
+}
+
+export { DEFAULT_W as W, DEFAULT_H as H };

--- a/risk-calculator/frontend/src/data/citations.json
+++ b/risk-calculator/frontend/src/data/citations.json
@@ -1,0 +1,62 @@
+{
+  "dbir-2024": {
+    "id": "dbir-2024",
+    "apa": "Verizon. (2024). 2024 Data Breach Investigations Report. Verizon Communications. https://www.verizon.com/business/resources/reports/dbir/",
+    "url": "https://www.verizon.com/business/resources/reports/dbir/"
+  },
+  "ibm-cost-2024": {
+    "id": "ibm-cost-2024",
+    "apa": "IBM Security. (2024). Cost of a Data Breach Report 2024. IBM Corporation. https://www.ibm.com/reports/data-breach",
+    "url": "https://www.ibm.com/reports/data-breach"
+  },
+  "cyentia-iris-2024": {
+    "id": "cyentia-iris-2024",
+    "apa": "Cyentia Institute. (2024). Information Risk Insights Study 2024. Cyentia Institute. https://www.cyentia.com/iris/",
+    "url": "https://www.cyentia.com/iris/"
+  },
+  "hhs-breach-portal": {
+    "id": "hhs-breach-portal",
+    "apa": "Office for Civil Rights, U.S. Department of Health and Human Services. (n.d.). Breach Portal: Notice to the Secretary of HHS Breach of Unsecured Protected Health Information. https://ocrportal.hhs.gov/ocr/breach/breach_report.jsf",
+    "url": "https://ocrportal.hhs.gov/ocr/breach/breach_report.jsf"
+  },
+  "itrc-2024": {
+    "id": "itrc-2024",
+    "apa": "Identity Theft Resource Center. (2024). 2023 Data Breach Report. Identity Theft Resource Center. https://www.idtheftcenter.org/publication/2023-data-breach-report/",
+    "url": "https://www.idtheftcenter.org/publication/2023-data-breach-report/"
+  },
+  "cisa-kev": {
+    "id": "cisa-kev",
+    "apa": "Cybersecurity and Infrastructure Security Agency. (n.d.). Known Exploited Vulnerabilities Catalog. U.S. Department of Homeland Security. https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+    "url": "https://www.cisa.gov/known-exploited-vulnerabilities-catalog"
+  },
+  "veris-vcdb": {
+    "id": "veris-vcdb",
+    "apa": "VERIS Community Database. (n.d.). VERIS Community Database. GitHub. https://github.com/vz-risk/VCDB",
+    "url": "https://github.com/vz-risk/VCDB"
+  },
+  "prc-chronology": {
+    "id": "prc-chronology",
+    "apa": "Privacy Rights Clearinghouse. (n.d.). Data Breach Chronology. Privacy Rights Clearinghouse. https://privacyrights.org/data-breaches",
+    "url": "https://privacyrights.org/data-breaches"
+  },
+  "cisa-critical-infra": {
+    "id": "cisa-critical-infra",
+    "apa": "Cybersecurity and Infrastructure Security Agency. (n.d.). Critical Infrastructure Sectors. U.S. Department of Homeland Security. https://www.cisa.gov/topics/critical-infrastructure-security-and-resilience/critical-infrastructure-sectors",
+    "url": "https://www.cisa.gov/topics/critical-infrastructure-security-and-resilience/critical-infrastructure-sectors"
+  },
+  "coppa-rule": {
+    "id": "coppa-rule",
+    "apa": "Federal Trade Commission. (2013). Children's Online Privacy Protection Rule (COPPA). 16 C.F.R. Part 312. https://www.ftc.gov/legal-library/browse/rules/childrens-online-privacy-protection-rule-coppa",
+    "url": "https://www.ftc.gov/legal-library/browse/rules/childrens-online-privacy-protection-rule-coppa"
+  },
+  "sec-cyber-rule-2023": {
+    "id": "sec-cyber-rule-2023",
+    "apa": "U.S. Securities and Exchange Commission. (2023). Cybersecurity Risk Management, Strategy, Governance, and Incident Disclosure. Final Rule. https://www.sec.gov/files/rules/final/2023/33-11216.pdf",
+    "url": "https://www.sec.gov/files/rules/final/2023/33-11216.pdf"
+  },
+  "open-fair": {
+    "id": "open-fair",
+    "apa": "The Open Group. (2021). The Open FAIR Body of Knowledge. The Open Group. https://www.opengroup.org/forum/security/riskmanagement",
+    "url": "https://www.opengroup.org/forum/security/riskmanagement"
+  }
+}

--- a/risk-calculator/frontend/src/data/citations.json
+++ b/risk-calculator/frontend/src/data/citations.json
@@ -54,6 +54,11 @@
     "apa": "U.S. Securities and Exchange Commission. (2023). Cybersecurity Risk Management, Strategy, Governance, and Incident Disclosure. Final Rule. https://www.sec.gov/files/rules/final/2023/33-11216.pdf",
     "url": "https://www.sec.gov/files/rules/final/2023/33-11216.pdf"
   },
+  "sec-sab-99": {
+    "id": "sec-sab-99",
+    "apa": "U.S. Securities and Exchange Commission. (1999). Staff Accounting Bulletin No. 99 — Materiality. Office of the Chief Accountant. https://www.sec.gov/interps/account/sab99.htm",
+    "url": "https://www.sec.gov/interps/account/sab99.htm"
+  },
   "open-fair": {
     "id": "open-fair",
     "apa": "The Open Group. (2021). The Open FAIR Body of Knowledge. The Open Group. https://www.opengroup.org/forum/security/riskmanagement",

--- a/risk-calculator/frontend/src/data/sector_defaults.json
+++ b/risk-calculator/frontend/src/data/sector_defaults.json
@@ -1,0 +1,127 @@
+{
+  "_meta": {
+    "vintage": "2026-Q2",
+    "disclaimer": "All values are illustrative defaults derived from public industry reports. Calibrate against your own loss data before use.",
+    "schema_version": "1.0.0"
+  },
+  "healthcare": {
+    "id": "healthcare",
+    "display_name": "Healthcare",
+    "classification": { "sic": ["8000-8099"], "naics": ["62"] },
+    "citations": ["hhs-breach-portal", "ibm-cost-2024", "dbir-2024"],
+    "defaults": {
+      "contactFrequency":       { "min": 30,       "likely": 60,       "max": 120 },
+      "probabilityOfAction":    { "min": 0.20,     "likely": 0.35,     "max": 0.55 },
+      "threatCapability":       { "min": 0.50,     "likely": 0.65,     "max": 0.80 },
+      "resistanceStrength":     { "min": 0.20,     "likely": 0.35,     "max": 0.50 },
+      "primaryLoss":            { "min": 500000,   "likely": 2500000,  "max": 11000000 },
+      "secondaryLossFrequency": { "min": 0.40,     "likely": 0.60,     "max": 0.80 },
+      "secondaryLossMagnitude": { "min": 200000,   "likely": 1000000,  "max": 5000000 }
+    }
+  },
+  "critical_infrastructure": {
+    "id": "critical_infrastructure",
+    "display_name": "Critical Infrastructure",
+    "classification": { "sic": ["various"], "naics": ["various"] },
+    "citations": ["cisa-critical-infra", "dbir-2024", "ibm-cost-2024"],
+    "defaults": {
+      "contactFrequency":       { "min": 10,       "likely": 25,       "max": 60 },
+      "probabilityOfAction":    { "min": 0.10,     "likely": 0.20,     "max": 0.40 },
+      "threatCapability":       { "min": 0.60,     "likely": 0.75,     "max": 0.90 },
+      "resistanceStrength":     { "min": 0.35,     "likely": 0.50,     "max": 0.65 },
+      "primaryLoss":            { "min": 1000000,  "likely": 5000000,  "max": 50000000 },
+      "secondaryLossFrequency": { "min": 0.50,     "likely": 0.70,     "max": 0.85 },
+      "secondaryLossMagnitude": { "min": 500000,   "likely": 3000000,  "max": 20000000 }
+    }
+  },
+  "social_media": {
+    "id": "social_media",
+    "display_name": "Social Media",
+    "classification": { "sic": ["7370"], "naics": ["519130"] },
+    "citations": ["dbir-2024", "cyentia-iris-2024", "veris-vcdb"],
+    "defaults": {
+      "contactFrequency":       { "min": 60,       "likely": 120,      "max": 240 },
+      "probabilityOfAction":    { "min": 0.20,     "likely": 0.35,     "max": 0.55 },
+      "threatCapability":       { "min": 0.40,     "likely": 0.55,     "max": 0.70 },
+      "resistanceStrength":     { "min": 0.40,     "likely": 0.55,     "max": 0.70 },
+      "primaryLoss":            { "min": 200000,   "likely": 1500000,  "max": 8000000 },
+      "secondaryLossFrequency": { "min": 0.30,     "likely": 0.50,     "max": 0.70 },
+      "secondaryLossMagnitude": { "min": 100000,   "likely": 750000,   "max": 4000000 }
+    }
+  },
+  "cloud": {
+    "id": "cloud",
+    "display_name": "Cloud",
+    "classification": { "sic": ["7372"], "naics": ["518210"] },
+    "citations": ["ibm-cost-2024", "cyentia-iris-2024", "dbir-2024"],
+    "defaults": {
+      "contactFrequency":       { "min": 20,       "likely": 50,       "max": 100 },
+      "probabilityOfAction":    { "min": 0.15,     "likely": 0.25,     "max": 0.40 },
+      "threatCapability":       { "min": 0.55,     "likely": 0.70,     "max": 0.85 },
+      "resistanceStrength":     { "min": 0.45,     "likely": 0.60,     "max": 0.75 },
+      "primaryLoss":            { "min": 500000,   "likely": 3000000,  "max": 15000000 },
+      "secondaryLossFrequency": { "min": 0.40,     "likely": 0.55,     "max": 0.75 },
+      "secondaryLossMagnitude": { "min": 300000,   "likely": 1500000,  "max": 8000000 }
+    }
+  },
+  "chip": {
+    "id": "chip",
+    "display_name": "Chip (Semiconductors)",
+    "classification": { "sic": ["3674"], "naics": ["334413"] },
+    "citations": ["dbir-2024", "cisa-kev", "ibm-cost-2024"],
+    "defaults": {
+      "contactFrequency":       { "min": 5,        "likely": 15,       "max": 35 },
+      "probabilityOfAction":    { "min": 0.10,     "likely": 0.20,     "max": 0.35 },
+      "threatCapability":       { "min": 0.65,     "likely": 0.80,     "max": 0.90 },
+      "resistanceStrength":     { "min": 0.40,     "likely": 0.55,     "max": 0.70 },
+      "primaryLoss":            { "min": 1000000,  "likely": 5000000,  "max": 50000000 },
+      "secondaryLossFrequency": { "min": 0.30,     "likely": 0.50,     "max": 0.70 },
+      "secondaryLossMagnitude": { "min": 500000,   "likely": 3000000,  "max": 25000000 }
+    }
+  },
+  "hardware": {
+    "id": "hardware",
+    "display_name": "Hardware",
+    "classification": { "sic": ["3570"], "naics": ["334"] },
+    "citations": ["dbir-2024", "cyentia-iris-2024"],
+    "defaults": {
+      "contactFrequency":       { "min": 8,        "likely": 20,       "max": 40 },
+      "probabilityOfAction":    { "min": 0.10,     "likely": 0.20,     "max": 0.35 },
+      "threatCapability":       { "min": 0.50,     "likely": 0.65,     "max": 0.80 },
+      "resistanceStrength":     { "min": 0.35,     "likely": 0.50,     "max": 0.65 },
+      "primaryLoss":            { "min": 500000,   "likely": 2000000,  "max": 10000000 },
+      "secondaryLossFrequency": { "min": 0.30,     "likely": 0.50,     "max": 0.70 },
+      "secondaryLossMagnitude": { "min": 200000,   "likely": 1000000,  "max": 5000000 }
+    }
+  },
+  "nonprofit": {
+    "id": "nonprofit",
+    "display_name": "Non-profits",
+    "classification": { "sic": ["8600"], "naics": ["813"] },
+    "citations": ["itrc-2024", "prc-chronology", "cyentia-iris-2024"],
+    "defaults": {
+      "contactFrequency":       { "min": 10,       "likely": 25,       "max": 50 },
+      "probabilityOfAction":    { "min": 0.15,     "likely": 0.30,     "max": 0.50 },
+      "threatCapability":       { "min": 0.40,     "likely": 0.55,     "max": 0.70 },
+      "resistanceStrength":     { "min": 0.20,     "likely": 0.35,     "max": 0.50 },
+      "primaryLoss":            { "min": 50000,    "likely": 300000,   "max": 2000000 },
+      "secondaryLossFrequency": { "min": 0.30,     "likely": 0.50,     "max": 0.70 },
+      "secondaryLossMagnitude": { "min": 30000,    "likely": 200000,   "max": 1000000 }
+    }
+  },
+  "gaming": {
+    "id": "gaming",
+    "display_name": "Gaming Platform",
+    "classification": { "sic": ["7372"], "naics": ["511210", "519130"] },
+    "citations": ["coppa-rule", "dbir-2024", "veris-vcdb", "itrc-2024"],
+    "defaults": {
+      "contactFrequency":       { "min": 100,      "likely": 250,      "max": 600 },
+      "probabilityOfAction":    { "min": 0.25,     "likely": 0.40,     "max": 0.60 },
+      "threatCapability":       { "min": 0.40,     "likely": 0.55,     "max": 0.75 },
+      "resistanceStrength":     { "min": 0.40,     "likely": 0.55,     "max": 0.70 },
+      "primaryLoss":            { "min": 300000,   "likely": 1500000,  "max": 8000000 },
+      "secondaryLossFrequency": { "min": 0.40,     "likely": 0.60,     "max": 0.80 },
+      "secondaryLossMagnitude": { "min": 200000,   "likely": 1000000,  "max": 5000000 }
+    }
+  }
+}

--- a/risk-calculator/frontend/src/index.css
+++ b/risk-calculator/frontend/src/index.css
@@ -1,0 +1,50 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+input,
+textarea {
+  field-sizing: content;
+}
+
+@media print {
+  @page {
+    size: landscape;
+    margin: 0.4in;
+  }
+
+  body {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  textarea {
+    field-sizing: content;
+    overflow: visible !important;
+    max-height: none !important;
+    min-height: 7.5em !important;
+    height: auto !important;
+  }
+
+  button[role="switch"],
+  .no-print {
+    display: none !important;
+  }
+}
+
+:root {
+  --bg: #ffffff;
+  --ink: #000000;
+  --input-blue: #1d4ed8;
+  --dial-grey: #9ca3af;
+  --button-grey: #e5e7eb;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}

--- a/risk-calculator/frontend/src/lib/api.ts
+++ b/risk-calculator/frontend/src/lib/api.ts
@@ -1,0 +1,35 @@
+import { InputKey, SimResult, Triangular } from "./state";
+
+const pert = (t: Triangular) => ({ type: "pert", min: t.min, likely: t.likely, max: t.max });
+
+export async function simulate(
+  inputs: Record<InputKey, Triangular>,
+  iterations: number,
+  seed = 42
+): Promise<SimResult> {
+  const payload = {
+    name: "Risk Scenario",
+    iterations,
+    seed,
+    contact_frequency: pert(inputs.contactFrequency),
+    probability_of_action: pert(inputs.probabilityOfAction),
+    threat_capability: pert(inputs.threatCapability),
+    resistance_strength: pert(inputs.resistanceStrength),
+    primary_loss: pert(inputs.primaryLoss),
+    secondary_loss_frequency: pert(inputs.secondaryLossFrequency),
+    secondary_loss_magnitude: pert(inputs.secondaryLossMagnitude),
+  };
+  const r = await fetch("/api/simulate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!r.ok) throw new Error(`simulate failed: ${r.status}`);
+  const data = await r.json();
+  return {
+    summary: data.summary,
+    histogram: data.histogram,
+    exceedance: data.exceedance,
+    iterations: data.iterations,
+  };
+}

--- a/risk-calculator/frontend/src/lib/compute.ts
+++ b/risk-calculator/frontend/src/lib/compute.ts
@@ -1,0 +1,72 @@
+import { Triangular } from "./state";
+
+export const mean = (t: Triangular) => (t.min + t.likely + t.max) / 3;
+
+export function vulnerabilityFromGrid(tcap: Triangular, rs: Triangular): number {
+  const grid = 21;
+  const tcapVals: number[] = [];
+  const rsVals: number[] = [];
+  for (let i = 0; i < grid; i++) {
+    const p = i / (grid - 1);
+    tcapVals.push(triPpf(p, tcap));
+    rsVals.push(triPpf(p, rs));
+  }
+  let negative = 0;
+  let total = 0;
+  for (let i = 0; i < grid; i++) {
+    for (let j = 0; j < grid; j++) {
+      if (i === j) continue;
+      total++;
+      if (rsVals[j] - tcapVals[i] < 0) negative++;
+    }
+  }
+  return total === 0 ? 0 : negative / total;
+}
+
+function triPpf(p: number, t: Triangular): number {
+  if (p <= 0) return t.min;
+  if (p >= 1) return t.max;
+  const c = (t.likely - t.min) / Math.max(t.max - t.min, 1e-12);
+  return p < c
+    ? t.min + Math.sqrt(p * (t.max - t.min) * (t.likely - t.min))
+    : t.max - Math.sqrt((1 - p) * (t.max - t.min) * (t.max - t.likely));
+}
+
+export function rollupTef(cf: Triangular, poa: Triangular): number {
+  return cf.likely * poa.likely;
+}
+
+export function rollupLef(tef: number, vuln: number): number {
+  return tef * vuln;
+}
+
+export function rollupSecondaryLoss(slef: Triangular, slm: Triangular): number {
+  return slef.likely * slm.likely;
+}
+
+export function rollupLm(pl: Triangular, sl: number): number {
+  return pl.likely + sl;
+}
+
+export function rollupRisk(lef: number, lm: number): number {
+  return lef * lm;
+}
+
+export function fmtUsd(v: number): string {
+  return `$${Math.round(v).toLocaleString("en-US")}`;
+}
+
+export function fmtUsdShort(v: number): string {
+  if (v >= 1_000_000_000) return `$${(v / 1_000_000_000).toFixed(1)}B`;
+  if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `$${(v / 1_000).toFixed(0)}K`;
+  return `$${Math.round(v)}`;
+}
+
+export function fmtPct(v: number): string {
+  return `${Math.round(v * 100)}%`;
+}
+
+export function fmtCount(v: number): string {
+  return `${Math.round(v)}`;
+}

--- a/risk-calculator/frontend/src/lib/state.ts
+++ b/risk-calculator/frontend/src/lib/state.ts
@@ -1,0 +1,161 @@
+import { create } from "zustand";
+
+export type Triangular = { min: number; likely: number; max: number };
+
+export type InputKey =
+  | "contactFrequency"
+  | "probabilityOfAction"
+  | "threatCapability"
+  | "resistanceStrength"
+  | "primaryLoss"
+  | "secondaryLossFrequency"
+  | "secondaryLossMagnitude";
+
+export const INPUT_META: Record<
+  InputKey,
+  { label: string; unit: string; bound: [number, number]; step: number }
+> = {
+  contactFrequency:       { label: "Contact Frequency",         unit: "per year",     bound: [0, 365],    step: 1 },
+  probabilityOfAction:    { label: "Probability of Action",     unit: "probability",  bound: [0, 1],      step: 0.01 },
+  threatCapability:       { label: "Threat Capability",         unit: "0 to 1",       bound: [0, 1],      step: 0.01 },
+  resistanceStrength:     { label: "Resistance Strength",       unit: "0 to 1",       bound: [0, 1],      step: 0.01 },
+  primaryLoss:            { label: "Primary Loss",              unit: "USD",          bound: [0, 1e9],    step: 1000 },
+  secondaryLossFrequency: { label: "Secondary Loss Frequency",  unit: "probability",  bound: [0, 1],      step: 0.01 },
+  secondaryLossMagnitude: { label: "Secondary Loss Magnitude",  unit: "USD",          bound: [0, 1e9],    step: 1000 },
+};
+
+const DEFAULTS: Record<InputKey, Triangular> = {
+  contactFrequency:       { min: 4,        likely: 12,       max: 36 },
+  probabilityOfAction:    { min: 0.05,     likely: 0.20,     max: 0.50 },
+  threatCapability:       { min: 0.40,     likely: 0.60,     max: 0.80 },
+  resistanceStrength:     { min: 0.30,     likely: 0.50,     max: 0.70 },
+  primaryLoss:            { min: 50_000,   likely: 250_000,  max: 1_000_000 },
+  secondaryLossFrequency: { min: 0.10,     likely: 0.30,     max: 0.60 },
+  secondaryLossMagnitude: { min: 25_000,   likely: 150_000,  max: 750_000 },
+};
+
+type Materiality = {
+  metric: "manual" | "market_cap" | "revenue" | "net_income";
+  value: number;
+  threshold: number;
+};
+
+export type ScenarioMetaKey =
+  | "scenarioNumber"
+  | "asset"
+  | "threatCommunity"
+  | "threatType"
+  | "effect";
+
+export type ScenarioMeta = Record<ScenarioMetaKey, string>;
+
+export type SimResult = {
+  summary: {
+    mean: number;
+    median: number;
+    p10: number;
+    p25: number;
+    p75: number;
+    p90: number;
+    p95: number;
+    var_95: number;
+    cvar_95: number;
+    min: number;
+    max: number;
+    std: number;
+  };
+  histogram: { counts: number[]; bins: number[] };
+  exceedance: { values: number[]; probabilities: number[] };
+  iterations: number;
+  tornado?: { input: string; rho: number }[];
+};
+
+type Store = {
+  inputs: Record<InputKey, Triangular>;
+  baselines: Record<InputKey, Triangular>;
+  rationales: Record<InputKey, string>;
+  sector: string;
+  iterations: number;
+  materiality: Materiality;
+  csfTiers: Record<string, number>;
+  csfTiersEnabled: boolean;
+  scenarioMeta: ScenarioMeta;
+  tableFrozen: boolean;
+  treeHidden: boolean;
+  result: SimResult | null;
+  running: boolean;
+  setLeaf: (key: InputKey, value: Triangular) => void;
+  setLikelyProportional: (key: InputKey, newLikely: number) => void;
+  setSector: (s: string, defaults: Record<InputKey, Triangular>) => void;
+  resetToBaseline: (key: InputKey) => void;
+  setRationale: (key: InputKey, value: string) => void;
+  setMateriality: (m: Partial<Materiality>) => void;
+  setCsfTier: (fn: string, tier: number) => void;
+  setCsfTiersEnabled: (b: boolean) => void;
+  setIterations: (n: number) => void;
+  setScenarioMeta: (key: ScenarioMetaKey, value: string) => void;
+  setTableFrozen: (b: boolean) => void;
+  setTreeHidden: (b: boolean) => void;
+  setResult: (r: SimResult | null) => void;
+  setRunning: (b: boolean) => void;
+};
+
+const EMPTY_RATIONALES: Record<InputKey, string> = {
+  contactFrequency: "",
+  probabilityOfAction: "",
+  threatCapability: "",
+  resistanceStrength: "",
+  primaryLoss: "",
+  secondaryLossFrequency: "",
+  secondaryLossMagnitude: "",
+};
+
+export const useStore = create<Store>((set) => ({
+  inputs: { ...DEFAULTS },
+  baselines: { ...DEFAULTS },
+  rationales: { ...EMPTY_RATIONALES },
+  sector: "custom",
+  iterations: 10000,
+  materiality: { metric: "manual", value: 1_000_000, threshold: 1.0 },
+  csfTiers: { identify: 2, protect: 2, detect: 2, respond: 2, recover: 2 },
+  csfTiersEnabled: false,
+  scenarioMeta: { scenarioNumber: "", asset: "", threatCommunity: "", threatType: "", effect: "" },
+  tableFrozen: false,
+  treeHidden: false,
+  result: null,
+  running: false,
+  setLeaf: (key, value) =>
+    set((s) => ({ inputs: { ...s.inputs, [key]: value } })),
+  setLikelyProportional: (key, newLikely) =>
+    set((s) => {
+      const current = s.inputs[key];
+      if (current.likely > 0 && Number.isFinite(newLikely)) {
+        const ratio = newLikely / current.likely;
+        const next = {
+          min: current.min * ratio,
+          likely: newLikely,
+          max: current.max * ratio,
+        };
+        return { inputs: { ...s.inputs, [key]: next } };
+      }
+      return { inputs: { ...s.inputs, [key]: { ...current, likely: newLikely } } };
+    }),
+  setSector: (sector, defaults) =>
+    set(() => ({ sector, baselines: defaults, inputs: { ...defaults } })),
+  resetToBaseline: (key) =>
+    set((s) => ({ inputs: { ...s.inputs, [key]: s.baselines[key] } })),
+  setRationale: (key, value) =>
+    set((s) => ({ rationales: { ...s.rationales, [key]: value } })),
+  setMateriality: (m) =>
+    set((s) => ({ materiality: { ...s.materiality, ...m } })),
+  setCsfTier: (fn, tier) =>
+    set((s) => ({ csfTiers: { ...s.csfTiers, [fn]: tier } })),
+  setCsfTiersEnabled: (b) => set(() => ({ csfTiersEnabled: b })),
+  setIterations: (n) => set(() => ({ iterations: n })),
+  setScenarioMeta: (key, value) =>
+    set((s) => ({ scenarioMeta: { ...s.scenarioMeta, [key]: value } })),
+  setTableFrozen: (b) => set(() => ({ tableFrozen: b })),
+  setTreeHidden: (b) => set(() => ({ treeHidden: b })),
+  setResult: (r) => set(() => ({ result: r })),
+  setRunning: (b) => set(() => ({ running: b })),
+}));

--- a/risk-calculator/frontend/src/lib/state.ts
+++ b/risk-calculator/frontend/src/lib/state.ts
@@ -82,6 +82,7 @@ type Store = {
   scenarioMeta: ScenarioMeta;
   tableFrozen: boolean;
   treeHidden: boolean;
+  referencesOpen: boolean;
   result: SimResult | null;
   running: boolean;
   setLeaf: (key: InputKey, value: Triangular) => void;
@@ -96,6 +97,7 @@ type Store = {
   setScenarioMeta: (key: ScenarioMetaKey, value: string) => void;
   setTableFrozen: (b: boolean) => void;
   setTreeHidden: (b: boolean) => void;
+  setReferencesOpen: (b: boolean) => void;
   setResult: (r: SimResult | null) => void;
   setRunning: (b: boolean) => void;
 };
@@ -122,6 +124,7 @@ export const useStore = create<Store>((set) => ({
   scenarioMeta: { scenarioNumber: "", asset: "", threatCommunity: "", threatType: "", effect: "" },
   tableFrozen: false,
   treeHidden: false,
+  referencesOpen: false,
   result: null,
   running: false,
   setLeaf: (key, value) =>
@@ -156,6 +159,7 @@ export const useStore = create<Store>((set) => ({
     set((s) => ({ scenarioMeta: { ...s.scenarioMeta, [key]: value } })),
   setTableFrozen: (b) => set(() => ({ tableFrozen: b })),
   setTreeHidden: (b) => set(() => ({ treeHidden: b })),
+  setReferencesOpen: (b) => set(() => ({ referencesOpen: b })),
   setResult: (r) => set(() => ({ result: r })),
   setRunning: (b) => set(() => ({ running: b })),
 }));

--- a/risk-calculator/frontend/src/main.tsx
+++ b/risk-calculator/frontend/src/main.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App";
+import "./index.css";
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/risk-calculator/frontend/tailwind.config.js
+++ b/risk-calculator/frontend/tailwind.config.js
@@ -1,0 +1,37 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  safelist: [
+    "text-input-pink",
+    "text-input-blue",
+    "bg-input-pink",
+    "bg-input-blue",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        ink: "#000000",
+        canvas: "#ffffff",
+        "input-blue": "#1d4ed8",
+        "input-blue-soft": "#3b82f6",
+        "input-pink": "#db2777",
+        "input-pink-soft": "#ec4899",
+        "dial-grey": "#9ca3af",
+        "button-grey": "#e5e7eb",
+        "panel-grey": "#f3f4f6",
+        "line-grey": "#d1d5db",
+      },
+      fontFamily: {
+        sans: [
+          "Inter",
+          "-apple-system",
+          "BlinkMacSystemFont",
+          "Segoe UI",
+          "Roboto",
+          "sans-serif",
+        ],
+      },
+    },
+  },
+  plugins: [],
+};

--- a/risk-calculator/frontend/tsconfig.json
+++ b/risk-calculator/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/risk-calculator/frontend/vite.config.ts
+++ b/risk-calculator/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5000,
+    strictPort: true,
+    proxy: {
+      "/api": {
+        target: "http://localhost:5001",
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/risk-calculator/webapp/database.py
+++ b/risk-calculator/webapp/database.py
@@ -11,8 +11,15 @@ db = SQLAlchemy()
 
 def init_db(app):
     """Initialize the database with the Flask application."""
-    db_path = os.environ.get('DB_PATH', '/tmp/fair_calculator.db')
-    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
+    default_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        'fair_calculator.db'
+    )
+    db_path = os.environ.get('DB_PATH', default_path)
+    db_path = os.path.abspath(db_path)
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    uri_path = db_path.replace('\\', '/')
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{uri_path}'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     db.init_app(app)
     with app.app_context():


### PR DESCRIPTION
## Summary
- Adds a Materiality Inputs table inside the tree canvas between the Scope Table and the Factor Analysis Tree.
- Four columns: Materiality Basis, Reference Value, Percent Threshold, Computed Materiality.
- A "(references)" link beside Materiality Basis opens a popover citing the Securities and Exchange Commission cybersecurity rule and Staff Accounting Bulletin number ninety-nine in American Psychological Association format.
- Plain English Results summary now reports the probability of exceeding materiality.
- Histogram and loss exceedance curve render a vertical reference line at the materiality value.
- Scenario Summary section gains a third horizontal table summarizing materiality.
- Tree canvas is now responsive: a ResizeObserver scales the canvas to fit the available page width.

## Dependencies
This pull request depends on pull request number nine (foundation), ten (results view), and eleven (sector defaults).

## Test plan
- [ ] Verify the Materiality Inputs table appears below the Scope Table inside the canvas
- [ ] Click "(references)" beside Materiality Basis and verify both citations open in a new tab
- [ ] Switch basis between Manual, Market Capitalization, Annual Revenue, and Net Income
- [ ] Verify Percent Threshold defaults change per basis and Computed Materiality updates
- [ ] Click Run Scenario and confirm the plain English summary includes probability of exceeding materiality
- [ ] Verify the histogram and exceedance curve show a vertical reference line at the materiality value
- [ ] Resize the browser window and confirm the canvas scales proportionally

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>